### PR TITLE
Refactor modal redirects and redesign music player

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,6 +132,17 @@ function App() {
     };
   }, [isAuthenticated]);
 
+  // Handle modal screen redirects
+  useEffect(() => {
+    if (
+      isAuthenticated &&
+      ["pet", "inventory", "profile", "admin"].includes(currentScreen)
+    ) {
+      setCurrentScreen("world");
+      setTimeout(() => openModal(currentScreen), 100);
+    }
+  }, [isAuthenticated, currentScreen]);
+
   const renderScreen = useMemo(() => {
     if (!isAuthenticated) {
       return <AuthScreen />;
@@ -162,9 +173,7 @@ function App() {
       case "inventory":
       case "profile":
       case "admin":
-        // Auto-redirect to world and open the modal
-        setCurrentScreen("world");
-        setTimeout(() => openModal(currentScreen), 100);
+        // Show SpaceMap while redirect is processing
         return (
           <>
             <SpaceMap />

--- a/src/components/Layout/DraggableModal.tsx
+++ b/src/components/Layout/DraggableModal.tsx
@@ -141,9 +141,7 @@ export const DraggableModal: React.FC<DraggableModalProps> = ({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-hidden">
-          <div className="h-full overflow-y-auto">{children}</div>
-        </div>
+        <div className="flex-1 overflow-hidden">{children}</div>
       </motion.div>
     </div>
   );

--- a/src/components/Layout/DraggableModal.tsx
+++ b/src/components/Layout/DraggableModal.tsx
@@ -125,20 +125,36 @@ export const DraggableModal: React.FC<DraggableModalProps> = ({
         onDragEnd={handleDragEnd}
         whileDrag={{ scale: 1.02 }}
       >
-        {/* Header */}
-        <div className="bg-white border-b border-gray-100 px-6 py-4 flex items-center justify-between select-none cursor-move">
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-          <div className="flex items-center space-x-2">
+        {/* Header - Only show if title exists */}
+        {title && (
+          <div className="bg-white border-b border-gray-100 px-6 py-4 flex items-center justify-between select-none cursor-move">
+            <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+            <div className="flex items-center space-x-2">
+              <motion.button
+                onClick={handleClose}
+                className="p-2 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+              >
+                <X className="w-4 h-4 text-gray-500" />
+              </motion.button>
+            </div>
+          </div>
+        )}
+
+        {/* Close button for headerless modals */}
+        {!title && (
+          <div className="absolute top-2 right-2 z-10">
             <motion.button
               onClick={handleClose}
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer"
+              className="p-1 hover:bg-gray-100 rounded-lg transition-colors cursor-pointer bg-white shadow-sm"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >
               <X className="w-4 h-4 text-gray-500" />
             </motion.button>
           </div>
-        </div>
+        )}
 
         {/* Content */}
         <div className="flex-1 overflow-hidden">{children}</div>

--- a/src/components/Layout/ModalManager.tsx
+++ b/src/components/Layout/ModalManager.tsx
@@ -60,7 +60,7 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
       profile: { width: 712, height: 750 }, // -25% horizontal (950 * 0.75 = 712)
       admin: { width: 950, height: 750 }, // Manter tamanho original
       notifications: { width: 380, height: 500 }, // Compact size for notifications
-      music: { width: 400, height: 400 }, // Increased height for volume bar
+      music: { width: 300, height: 250 }, // Compact minimalist size
     };
     return sizes[modalId as keyof typeof sizes] || { width: 950, height: 750 };
   };

--- a/src/components/Layout/ModalManager.tsx
+++ b/src/components/Layout/ModalManager.tsx
@@ -88,7 +88,7 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
     },
     {
       id: "music",
-      title: "Música",
+      title: "",
       component: <MusicModal />,
     },
     ...(user?.isAdmin

--- a/src/components/Layout/ModalManager.tsx
+++ b/src/components/Layout/ModalManager.tsx
@@ -89,9 +89,7 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
     {
       id: "music",
       title: "Música",
-      component: (
-        <MusicModal isOpen={true} onClose={() => onCloseModal("music")} />
-      ),
+      component: <MusicModal />,
     },
     ...(user?.isAdmin
       ? [

--- a/src/components/Layout/ModalManager.tsx
+++ b/src/components/Layout/ModalManager.tsx
@@ -60,7 +60,7 @@ export const ModalManager: React.FC<ModalManagerProps> = ({
       profile: { width: 712, height: 750 }, // -25% horizontal (950 * 0.75 = 712)
       admin: { width: 950, height: 750 }, // Manter tamanho original
       notifications: { width: 380, height: 500 }, // Compact size for notifications
-      music: { width: 450, height: 300 }, // Compact size for music player
+      music: { width: 400, height: 400 }, // Increased height for volume bar
     };
     return sizes[modalId as keyof typeof sizes] || { width: 950, height: 750 };
   };

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -10,12 +10,7 @@ import { motion } from "framer-motion";
 import { useGameStore } from "../../store/gameStore";
 import { useMusicContext } from "../../contexts/MusicContext";
 
-interface MusicModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-export const MusicModal: React.FC<MusicModalProps> = ({ isOpen, onClose }) => {
+export const MusicModal: React.FC = () => {
   const { user } = useGameStore();
   const {
     isPlaying,
@@ -28,10 +23,8 @@ export const MusicModal: React.FC<MusicModalProps> = ({ isOpen, onClose }) => {
     previousTrack,
   } = useMusicContext();
 
-  if (!isOpen) return null;
-
   return (
-    <div className="w-96 bg-white rounded-2xl shadow-xl border border-gray-100 overflow-hidden">
+    <div className="p-4">
       {/* Header */}
       <div className="p-4 border-b border-gray-100 bg-gradient-to-r from-blue-50 to-purple-50">
         <div className="flex items-center justify-between">

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -53,12 +53,12 @@ export const MusicModal: React.FC = () => {
 
         <button
           onClick={togglePlayPause}
-          className="w-6 h-6 rounded bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center flex-shrink-0"
+          className="text-blue-600 hover:text-blue-700 transition-colors flex-shrink-0 p-0"
         >
           {isPlaying ? (
-            <Pause className="w-3 h-3 text-white" />
+            <Pause className="w-4 h-4" />
           ) : (
-            <Play className="w-3 h-3 text-white ml-0.5" />
+            <Play className="w-4 h-4" />
           )}
         </button>
 

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -12,33 +12,32 @@ import { useMusicContext } from "../../contexts/MusicContext";
 
 export const MusicModal: React.FC = () => {
   const { user } = useGameStore();
-  const {
-    isPlaying,
-    currentTrack,
-    isLoading,
-    volume,
-    setVolume,
-    togglePlayPause,
-    nextTrack,
-    previousTrack,
-  } = useMusicContext();
+  const { isPlaying, currentTrack, volume, setVolume, play, pause } =
+    useMusicContext();
+
+  const togglePlayPause = () => {
+    if (isPlaying) {
+      pause();
+    } else {
+      play();
+    }
+  };
 
   return (
     <div className="p-6 h-full flex flex-col justify-center items-center">
       {/* Cover Image */}
-      <div className="w-32 h-32 bg-gradient-to-br from-blue-400 via-blue-500 to-purple-600 rounded-2xl mb-6 flex items-center justify-center shadow-lg">
-        <MusicIcon className="w-16 h-16 text-white" />
+      <div className="w-40 h-40 bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600 rounded-3xl mb-6 flex items-center justify-center shadow-2xl relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"></div>
+        <MusicIcon className="w-20 h-20 text-white z-10" />
+        <div className="absolute bottom-2 right-2 w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
       </div>
 
       {/* Track Info */}
       <div className="text-center mb-8">
-        <h4 className="font-semibold text-gray-900 mb-1 text-lg">
+        <h4 className="font-bold text-gray-900 mb-2 text-xl">
           {currentTrack?.name || "Música Galáctica"}
         </h4>
-        <p className="text-sm text-gray-600">XenoPets Soundtrack</p>
-        <p className="text-xs text-gray-500 mt-2">
-          Olá, {user?.username || "Jogador"}!
-        </p>
+        <p className="text-sm text-gray-600 font-medium">XenoPets Soundtrack</p>
       </div>
 
       {/* Play/Pause Control */}
@@ -50,9 +49,7 @@ export const MusicModal: React.FC = () => {
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
         >
-          {isLoading ? (
-            <div className="w-8 h-8 border-3 border-white border-t-transparent rounded-full animate-spin" />
-          ) : isPlaying ? (
+          {isPlaying ? (
             <Pause className="w-8 h-8 text-white" />
           ) : (
             <Play className="w-8 h-8 text-white ml-1" />
@@ -75,19 +72,28 @@ export const MusicModal: React.FC = () => {
             <Volume2 className="w-5 h-5 text-blue-600" />
           )}
           <div className="flex-1 relative">
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.05"
-              value={volume}
-              onChange={(e) => setVolume(Number(e.target.value))}
-              className="w-full h-3 bg-gray-200 rounded-full appearance-none cursor-pointer"
-              style={{
-                background: `linear-gradient(to right, #3b82f6 0%, #60a5fa ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
-                boxShadow: `0 0 10px rgba(59, 130, 246, ${volume * 0.5})`,
-              }}
-            />
+            <div className="relative">
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.05"
+                value={volume}
+                onChange={(e) => setVolume(Number(e.target.value))}
+                className="w-full h-4 bg-gray-200 rounded-full appearance-none cursor-pointer slider-luminous"
+                style={{
+                  background: `linear-gradient(to right, #2563eb 0%, #3b82f6 ${volume * 50}%, #60a5fa ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
+                }}
+              />
+              <div
+                className="absolute top-0 left-0 h-4 bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full pointer-events-none transition-all duration-200"
+                style={{
+                  width: `${volume * 100}%`,
+                  boxShadow: `0 0 20px rgba(59, 130, 246, ${volume * 0.8}), 0 0 40px rgba(59, 130, 246, ${volume * 0.4})`,
+                  filter: `brightness(${1 + volume * 0.5})`,
+                }}
+              ></div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -59,18 +59,16 @@ export const MusicModal: React.FC = () => {
       <div className="flex items-center gap-2">
         <Volume2 className="w-4 h-4 text-blue-600 flex-shrink-0" />
 
-        <motion.button
+        <button
           onClick={togglePlayPause}
-          className="w-6 h-6 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center flex-shrink-0"
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
+          className="w-6 h-6 rounded bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center flex-shrink-0"
         >
           {isPlaying ? (
             <Pause className="w-3 h-3 text-white" />
           ) : (
             <Play className="w-3 h-3 text-white ml-0.5" />
           )}
-        </motion.button>
+        </button>
 
         <div className="flex-1 relative">
           <div className="w-full h-1.5 bg-gray-200 rounded-full">
@@ -89,7 +87,12 @@ export const MusicModal: React.FC = () => {
             max="1"
             step="0.05"
             value={volume}
-            onChange={(e) => setVolume(Number(e.target.value))}
+            onChange={(e) => {
+              e.stopPropagation();
+              setVolume(Number(e.target.value));
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
             className="absolute inset-0 w-full opacity-0 cursor-pointer"
           />
         </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -33,7 +33,7 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-8 h-8 text-white" />
+              <MusicIcon className="w-10 h-10 text-white" />
             </div>
           )}
         </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,10 +24,10 @@ export const MusicModal: React.FC = () => {
   };
 
   return (
-    <div className="p-4 h-full flex flex-col">
+    <div className="p-3 h-full flex flex-col justify-between">
       {/* Cover Image */}
-      <div className="flex justify-center mb-3">
-        <div className="w-16 h-16 rounded-xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-md">
+      <div className="flex justify-center">
+        <div className="w-14 h-14 rounded-lg overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -40,24 +40,24 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-8 h-8 text-white" />
+              <MusicIcon className="w-7 h-7 text-white" />
             </div>
           )}
         </div>
       </div>
 
       {/* Track Name */}
-      <div className="text-center mb-3">
-        <h4 className="font-medium text-gray-900 text-sm truncate">
+      <div className="text-center">
+        <h4 className="font-medium text-gray-900 text-sm truncate px-2">
           {currentTrack?.name || "Música Galáctica"}
         </h4>
       </div>
 
       {/* Play/Pause Button */}
-      <div className="flex justify-center mb-4">
+      <div className="flex justify-center">
         <motion.button
           onClick={togglePlayPause}
-          className="w-10 h-10 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center"
+          className="w-9 h-9 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
         >
@@ -69,17 +69,17 @@ export const MusicModal: React.FC = () => {
         </motion.button>
       </div>
 
-      {/* Volume Bar */}
-      <div className="mt-auto">
+      {/* Volume Bar - GUARANTEED VISIBLE */}
+      <div className="bg-blue-50 rounded-lg p-2">
         <div className="flex items-center gap-2">
-          <Volume2 className="w-3 h-3 text-gray-400 flex-shrink-0" />
-          <div className="flex-1 relative">
-            <div className="w-full h-1 bg-gray-200 rounded-full">
+          <Volume2 className="w-3 h-3 text-blue-600 flex-shrink-0" />
+          <div className="flex-1 relative h-3 flex items-center">
+            <div className="w-full h-1.5 bg-blue-200 rounded-full">
               <div
                 className="h-full bg-blue-500 rounded-full transition-all duration-200"
                 style={{
                   width: `${volume * 100}%`,
-                  boxShadow: `0 0 6px rgba(59, 130, 246, 0.8)`,
+                  boxShadow: `0 0 4px rgba(59, 130, 246, 0.8)`,
                 }}
               ></div>
             </div>
@@ -93,7 +93,7 @@ export const MusicModal: React.FC = () => {
               className="absolute inset-0 w-full opacity-0 cursor-pointer"
             />
           </div>
-          <span className="text-xs text-gray-500 w-8 text-right">
+          <span className="text-xs text-blue-700 font-medium w-8 text-center">
             {Math.round(volume * 100)}%
           </span>
         </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,10 +24,10 @@ export const MusicModal: React.FC = () => {
   };
 
   return (
-    <div className="p-6">
+    <div className="p-4 h-full flex flex-col">
       {/* Cover Image */}
-      <div className="text-center mb-4">
-        <div className="w-24 h-24 mx-auto rounded-2xl shadow-lg relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
+      <div className="flex justify-center mb-3">
+        <div className="w-16 h-16 rounded-xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-md">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -40,64 +40,49 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-12 h-12 text-white" />
+              <MusicIcon className="w-8 h-8 text-white" />
             </div>
           )}
-          {isPlaying && (
-            <div className="absolute top-1 right-1 w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
-          )}
         </div>
-
-        {/* Track Info */}
-        <h4 className="font-semibold text-gray-900 text-base mt-3 mb-1">
-          {currentTrack?.name || "Música Galáctica"}
-        </h4>
-        <p className="text-xs text-gray-500">XenoPets</p>
       </div>
 
-      {/* Play/Pause Control */}
-      <div className="text-center mb-6">
+      {/* Track Name */}
+      <div className="text-center mb-3">
+        <h4 className="font-medium text-gray-900 text-sm truncate">
+          {currentTrack?.name || "Música Galáctica"}
+        </h4>
+      </div>
+
+      {/* Play/Pause Button */}
+      <div className="flex justify-center mb-4">
         <motion.button
           onClick={togglePlayPause}
-          className="w-12 h-12 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-lg flex items-center justify-center mx-auto"
+          className="w-10 h-10 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
         >
           {isPlaying ? (
-            <Pause className="w-5 h-5 text-white" />
+            <Pause className="w-4 h-4 text-white" />
           ) : (
-            <Play className="w-5 h-5 text-white ml-0.5" />
+            <Play className="w-4 h-4 text-white ml-0.5" />
           )}
         </motion.button>
       </div>
 
-      {/* VOLUME BAR - SUPER VISIBLE */}
-      <div className="bg-blue-50 border-2 border-blue-200 rounded-xl p-4">
-        <div className="flex items-center justify-between mb-3">
-          <span className="text-sm font-semibold text-gray-800">VOLUME</span>
-          <span className="text-sm text-blue-700 font-bold bg-blue-100 px-2 py-1 rounded">
-            {Math.round(volume * 100)}%
-          </span>
-        </div>
-
-        <div className="flex items-center gap-3">
-          {volume === 0 ? (
-            <VolumeX className="w-5 h-5 text-gray-500" />
-          ) : (
-            <Volume2 className="w-5 h-5 text-blue-600" />
-          )}
-
+      {/* Volume Bar */}
+      <div className="mt-auto">
+        <div className="flex items-center gap-2">
+          <Volume2 className="w-3 h-3 text-gray-400 flex-shrink-0" />
           <div className="flex-1 relative">
-            <div className="w-full h-3 bg-white border border-gray-300 rounded-full shadow-inner">
+            <div className="w-full h-1 bg-gray-200 rounded-full">
               <div
-                className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-300 shadow-lg"
+                className="h-full bg-blue-500 rounded-full transition-all duration-200"
                 style={{
                   width: `${volume * 100}%`,
-                  boxShadow: `0 0 12px rgba(59, 130, 246, 0.8), inset 0 1px 2px rgba(255,255,255,0.3)`,
+                  boxShadow: `0 0 6px rgba(59, 130, 246, 0.8)`,
                 }}
               ></div>
             </div>
-
             <input
               type="range"
               min="0"
@@ -106,9 +91,11 @@ export const MusicModal: React.FC = () => {
               value={volume}
               onChange={(e) => setVolume(Number(e.target.value))}
               className="absolute inset-0 w-full opacity-0 cursor-pointer"
-              style={{ height: "12px" }}
             />
           </div>
+          <span className="text-xs text-gray-500 w-8 text-right">
+            {Math.round(volume * 100)}%
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,10 +24,10 @@ export const MusicModal: React.FC = () => {
   };
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="p-6">
       {/* Cover Image */}
-      <div className="flex items-center justify-center">
-        <div className="w-20 h-20 rounded-xl shadow-lg relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
+      <div className="text-center mb-4">
+        <div className="w-24 h-24 mx-auto rounded-2xl shadow-lg relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -40,72 +40,64 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-10 h-10 text-white" />
+              <MusicIcon className="w-12 h-12 text-white" />
             </div>
           )}
           {isPlaying && (
             <div className="absolute top-1 right-1 w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
           )}
         </div>
-      </div>
 
-      {/* Track Info */}
-      <div className="text-center">
-        <h4 className="font-semibold text-gray-900 text-sm leading-tight mb-1 truncate">
+        {/* Track Info */}
+        <h4 className="font-semibold text-gray-900 text-base mt-3 mb-1">
           {currentTrack?.name || "Música Galáctica"}
         </h4>
         <p className="text-xs text-gray-500">XenoPets</p>
       </div>
 
       {/* Play/Pause Control */}
-      <div className="flex justify-center">
+      <div className="text-center mb-6">
         <motion.button
           onClick={togglePlayPause}
-          className="w-10 h-10 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-md flex items-center justify-center"
+          className="w-12 h-12 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-lg flex items-center justify-center mx-auto"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
         >
           {isPlaying ? (
-            <Pause className="w-4 h-4 text-white" />
+            <Pause className="w-5 h-5 text-white" />
           ) : (
-            <Play className="w-4 h-4 text-white ml-0.5" />
+            <Play className="w-5 h-5 text-white ml-0.5" />
           )}
         </motion.button>
       </div>
 
-      {/* Volume Control - GUARANTEED VISIBLE */}
-      <div className="bg-gray-50 rounded-lg p-3 border border-gray-200">
-        <div className="flex items-center justify-between mb-2">
-          <span className="text-xs font-medium text-gray-700">Volume</span>
-          <span className="text-xs text-blue-600 font-bold">
+      {/* VOLUME BAR - SUPER VISIBLE */}
+      <div className="bg-blue-50 border-2 border-blue-200 rounded-xl p-4">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-sm font-semibold text-gray-800">VOLUME</span>
+          <span className="text-sm text-blue-700 font-bold bg-blue-100 px-2 py-1 rounded">
             {Math.round(volume * 100)}%
           </span>
         </div>
 
-        <div className="flex items-center gap-2">
-          <div className="flex-shrink-0">
-            {volume === 0 ? (
-              <VolumeX className="w-4 h-4 text-gray-400" />
-            ) : (
-              <Volume2 className="w-4 h-4 text-blue-600" />
-            )}
-          </div>
+        <div className="flex items-center gap-3">
+          {volume === 0 ? (
+            <VolumeX className="w-5 h-5 text-gray-500" />
+          ) : (
+            <Volume2 className="w-5 h-5 text-blue-600" />
+          )}
 
-          <div className="flex-1 relative h-4 flex items-center">
-            {/* Background track */}
-            <div className="w-full h-2 bg-gray-300 rounded-full"></div>
+          <div className="flex-1 relative">
+            <div className="w-full h-3 bg-white border border-gray-300 rounded-full shadow-inner">
+              <div
+                className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-300 shadow-lg"
+                style={{
+                  width: `${volume * 100}%`,
+                  boxShadow: `0 0 12px rgba(59, 130, 246, 0.8), inset 0 1px 2px rgba(255,255,255,0.3)`,
+                }}
+              ></div>
+            </div>
 
-            {/* Progress/volume fill with glow */}
-            <div
-              className="absolute left-0 h-2 bg-gradient-to-r from-blue-500 to-blue-400 rounded-full transition-all duration-200"
-              style={{
-                width: `${volume * 100}%`,
-                boxShadow: `0 0 8px rgba(59, 130, 246, 0.8)`,
-                filter: "brightness(1.2)",
-              }}
-            ></div>
-
-            {/* Invisible input overlay */}
             <input
               type="range"
               min="0"
@@ -113,7 +105,8 @@ export const MusicModal: React.FC = () => {
               step="0.05"
               value={volume}
               onChange={(e) => setVolume(Number(e.target.value))}
-              className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+              className="absolute inset-0 w-full opacity-0 cursor-pointer"
+              style={{ height: "12px" }}
             />
           </div>
         </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -73,8 +73,8 @@ export const MusicModal: React.FC = () => {
         </motion.button>
       </div>
 
-      {/* Volume Control - Compact */}
-      <div className="flex-1 flex flex-col justify-end">
+      {/* Volume Control - Always Visible */}
+      <div className="mt-auto">
         <div className="flex items-center justify-between mb-2">
           <span className="text-xs font-medium text-gray-600">Volume</span>
           <span className="text-xs text-blue-600 font-semibold">
@@ -95,16 +95,16 @@ export const MusicModal: React.FC = () => {
               step="0.05"
               value={volume}
               onChange={(e) => setVolume(Number(e.target.value))}
-              className="w-full h-2 bg-gray-200 rounded-full appearance-none cursor-pointer slider-luminous"
+              className="w-full h-3 bg-gray-200 rounded-full appearance-none cursor-pointer slider-luminous"
               style={{
                 background: `linear-gradient(to right, #3b82f6 0%, #60a5fa ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
               }}
             />
             <div
-              className="absolute top-0 left-0 h-2 bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full pointer-events-none transition-all duration-200"
+              className="absolute top-0 left-0 h-3 bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full pointer-events-none transition-all duration-200"
               style={{
                 width: `${volume * 100}%`,
-                boxShadow: `0 0 8px rgba(59, 130, 246, ${volume * 0.6})`,
+                boxShadow: `0 0 12px rgba(59, 130, 246, ${volume * 0.8}), 0 0 20px rgba(59, 130, 246, ${volume * 0.4})`,
               }}
             ></div>
           </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,26 +24,22 @@ export const MusicModal: React.FC = () => {
   } = useMusicContext();
 
   return (
-    <div className="p-4">
+    <div className="space-y-4">
       {/* Header */}
-      <div className="p-4 border-b border-gray-100 bg-gradient-to-r from-blue-50 to-purple-50">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-blue-100 rounded-lg">
-              <MusicIcon className="w-5 h-5 text-blue-600" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-gray-900">Player de Música</h3>
-              <p className="text-sm text-gray-600">
-                Olá, {user?.username || "Jogador"}!
-              </p>
-            </div>
-          </div>
+      <div className="flex items-center gap-3 p-4 border-b border-gray-100 bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg">
+        <div className="p-2 bg-blue-100 rounded-lg">
+          <MusicIcon className="w-5 h-5 text-blue-600" />
+        </div>
+        <div>
+          <h3 className="font-semibold text-gray-900">Player de Música</h3>
+          <p className="text-sm text-gray-600">
+            Olá, {user?.username || "Jogador"}!
+          </p>
         </div>
       </div>
 
       {/* Music Player Content */}
-      <div className="p-6">
+      <div className="px-2">
         {/* Track Info */}
         <div className="text-center mb-6">
           <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-purple-500 rounded-full mx-auto mb-3 flex items-center justify-center">

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,10 +24,10 @@ export const MusicModal: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col h-full p-4">
-      {/* Cover Image - Compact */}
-      <div className="flex items-center justify-center mb-4">
-        <div className="w-24 h-24 rounded-2xl shadow-lg relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
+    <div className="p-4 space-y-4">
+      {/* Cover Image */}
+      <div className="flex items-center justify-center">
+        <div className="w-20 h-20 rounded-xl shadow-lg relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -40,7 +40,7 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-12 h-12 text-white" />
+              <MusicIcon className="w-10 h-10 text-white" />
             </div>
           )}
           {isPlaying && (
@@ -49,45 +49,63 @@ export const MusicModal: React.FC = () => {
         </div>
       </div>
 
-      {/* Track Info - Compact */}
-      <div className="text-center mb-4">
-        <h4 className="font-semibold text-gray-900 text-base leading-tight mb-1 truncate">
+      {/* Track Info */}
+      <div className="text-center">
+        <h4 className="font-semibold text-gray-900 text-sm leading-tight mb-1 truncate">
           {currentTrack?.name || "Música Galáctica"}
         </h4>
         <p className="text-xs text-gray-500">XenoPets</p>
       </div>
 
-      {/* Play/Pause Control - Compact */}
-      <div className="flex justify-center mb-4">
+      {/* Play/Pause Control */}
+      <div className="flex justify-center">
         <motion.button
           onClick={togglePlayPause}
-          className="w-12 h-12 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-md flex items-center justify-center"
+          className="w-10 h-10 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-md flex items-center justify-center"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
         >
           {isPlaying ? (
-            <Pause className="w-5 h-5 text-white" />
+            <Pause className="w-4 h-4 text-white" />
           ) : (
-            <Play className="w-5 h-5 text-white ml-0.5" />
+            <Play className="w-4 h-4 text-white ml-0.5" />
           )}
         </motion.button>
       </div>
 
-      {/* Volume Control - Always Visible */}
-      <div className="mt-auto">
+      {/* Volume Control - GUARANTEED VISIBLE */}
+      <div className="bg-gray-50 rounded-lg p-3 border border-gray-200">
         <div className="flex items-center justify-between mb-2">
-          <span className="text-xs font-medium text-gray-600">Volume</span>
-          <span className="text-xs text-blue-600 font-semibold">
+          <span className="text-xs font-medium text-gray-700">Volume</span>
+          <span className="text-xs text-blue-600 font-bold">
             {Math.round(volume * 100)}%
           </span>
         </div>
+
         <div className="flex items-center gap-2">
-          {volume === 0 ? (
-            <VolumeX className="w-4 h-4 text-gray-400 flex-shrink-0" />
-          ) : (
-            <Volume2 className="w-4 h-4 text-blue-600 flex-shrink-0" />
-          )}
-          <div className="flex-1 relative">
+          <div className="flex-shrink-0">
+            {volume === 0 ? (
+              <VolumeX className="w-4 h-4 text-gray-400" />
+            ) : (
+              <Volume2 className="w-4 h-4 text-blue-600" />
+            )}
+          </div>
+
+          <div className="flex-1 relative h-4 flex items-center">
+            {/* Background track */}
+            <div className="w-full h-2 bg-gray-300 rounded-full"></div>
+
+            {/* Progress/volume fill with glow */}
+            <div
+              className="absolute left-0 h-2 bg-gradient-to-r from-blue-500 to-blue-400 rounded-full transition-all duration-200"
+              style={{
+                width: `${volume * 100}%`,
+                boxShadow: `0 0 8px rgba(59, 130, 246, 0.8)`,
+                filter: "brightness(1.2)",
+              }}
+            ></div>
+
+            {/* Invisible input overlay */}
             <input
               type="range"
               min="0"
@@ -95,18 +113,8 @@ export const MusicModal: React.FC = () => {
               step="0.05"
               value={volume}
               onChange={(e) => setVolume(Number(e.target.value))}
-              className="w-full h-3 bg-gray-200 rounded-full appearance-none cursor-pointer slider-luminous"
-              style={{
-                background: `linear-gradient(to right, #3b82f6 0%, #60a5fa ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
-              }}
+              className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
             />
-            <div
-              className="absolute top-0 left-0 h-3 bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full pointer-events-none transition-all duration-200"
-              style={{
-                width: `${volume * 100}%`,
-                boxShadow: `0 0 12px rgba(59, 130, 246, ${volume * 0.8}), 0 0 20px rgba(59, 130, 246, ${volume * 0.4})`,
-              }}
-            ></div>
           </div>
         </div>
       </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,10 +24,10 @@ export const MusicModal: React.FC = () => {
   };
 
   return (
-    <div className="p-3 h-full flex flex-col justify-between">
-      {/* Cover Image */}
-      <div className="flex justify-center">
-        <div className="w-14 h-14 rounded-lg overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900">
+    <div className="p-4 h-full flex flex-col">
+      {/* Large Cover Image */}
+      <div className="flex justify-center mb-3">
+        <div className="w-24 h-24 rounded-2xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-lg">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -40,46 +40,53 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-7 h-7 text-white" />
+              <MusicIcon className="w-12 h-12 text-white" />
             </div>
           )}
         </div>
       </div>
 
       {/* Track Name */}
-      <div className="text-center">
+      <div className="text-center mb-4">
         <h4 className="font-medium text-gray-900 text-sm truncate px-2">
           {currentTrack?.name || "Música Galáctica"}
         </h4>
       </div>
 
-      {/* Play/Pause Button */}
-      <div className="flex justify-center">
-        <motion.button
-          onClick={togglePlayPause}
-          className="w-9 h-9 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center"
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
-        >
-          {isPlaying ? (
-            <Pause className="w-4 h-4 text-white" />
-          ) : (
-            <Play className="w-4 h-4 text-white ml-0.5" />
-          )}
-        </motion.button>
-      </div>
+      {/* Controls Row: Volume icon + Play button + Volume bar */}
+      <div className="mt-auto">
+        <div className="flex items-center gap-3">
+          {/* Volume Icon */}
+          <Volume2 className="w-4 h-4 text-blue-600 flex-shrink-0" />
 
-      {/* Volume Bar - GUARANTEED VISIBLE */}
-      <div className="bg-blue-50 rounded-lg p-2">
-        <div className="flex items-center gap-2">
-          <Volume2 className="w-3 h-3 text-blue-600 flex-shrink-0" />
-          <div className="flex-1 relative h-3 flex items-center">
-            <div className="w-full h-1.5 bg-blue-200 rounded-full">
+          {/* Minimalist Play Button */}
+          <motion.button
+            onClick={togglePlayPause}
+            className="w-7 h-7 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center flex-shrink-0"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            {isPlaying ? (
+              <Pause className="w-3 h-3 text-white" />
+            ) : (
+              <Play className="w-3 h-3 text-white ml-0.5" />
+            )}
+          </motion.button>
+
+          {/* Super Luminous Volume Bar */}
+          <div className="flex-1 relative h-4 flex items-center">
+            <div className="w-full h-2 bg-gray-200 rounded-full shadow-inner">
               <div
-                className="h-full bg-blue-500 rounded-full transition-all duration-200"
+                className="h-full bg-gradient-to-r from-blue-400 to-cyan-400 rounded-full transition-all duration-300"
                 style={{
                   width: `${volume * 100}%`,
-                  boxShadow: `0 0 4px rgba(59, 130, 246, 0.8)`,
+                  boxShadow: `
+                    0 0 8px rgba(59, 130, 246, 1),
+                    0 0 16px rgba(59, 130, 246, 0.8),
+                    0 0 24px rgba(59, 130, 246, 0.6),
+                    inset 0 1px 2px rgba(255, 255, 255, 0.3)
+                  `,
+                  filter: "brightness(1.3) saturate(1.2)",
                 }}
               ></div>
             </div>
@@ -93,7 +100,9 @@ export const MusicModal: React.FC = () => {
               className="absolute inset-0 w-full opacity-0 cursor-pointer"
             />
           </div>
-          <span className="text-xs text-blue-700 font-medium w-8 text-center">
+
+          {/* Volume Percentage */}
+          <span className="text-xs text-blue-700 font-semibold w-8 text-center">
             {Math.round(volume * 100)}%
           </span>
         </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -65,8 +65,7 @@ export const MusicModal: React.FC = () => {
       <div className="mb-8">
         <motion.button
           onClick={togglePlayPause}
-          disabled={isLoading}
-          className="p-4 rounded-full bg-blue-500 hover:bg-blue-600 disabled:opacity-50 transition-colors shadow-lg"
+          className="p-4 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-lg"
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
         >

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -26,10 +26,31 @@ export const MusicModal: React.FC = () => {
   return (
     <div className="p-6 h-full flex flex-col justify-center items-center">
       {/* Cover Image */}
-      <div className="w-40 h-40 bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600 rounded-3xl mb-6 flex items-center justify-center shadow-2xl relative overflow-hidden">
-        <div className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"></div>
-        <MusicIcon className="w-20 h-20 text-white z-10" />
-        <div className="absolute bottom-2 right-2 w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
+      <div className="w-40 h-40 rounded-3xl mb-6 shadow-2xl relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
+        {currentTrack?.coverImage ? (
+          <>
+            <img
+              src={currentTrack.coverImage}
+              alt={currentTrack.name}
+              className="w-full h-full object-cover"
+              onError={(e) => {
+                // Fallback to gradient background
+                e.currentTarget.style.display = "none";
+              }}
+            />
+            <div className="absolute inset-0 bg-gradient-to-br from-white/10 to-black/20"></div>
+          </>
+        ) : (
+          <>
+            <div className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"></div>
+            <div className="w-full h-full flex items-center justify-center">
+              <MusicIcon className="w-20 h-20 text-white z-10" />
+            </div>
+          </>
+        )}
+        {isPlaying && (
+          <div className="absolute bottom-2 right-2 w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
+        )}
       </div>
 
       {/* Track Info */}

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,10 +24,11 @@ export const MusicModal: React.FC = () => {
   };
 
   return (
-    <div className="p-4 h-full flex flex-col">
-      {/* Large Cover Image */}
-      <div className="flex justify-center mb-3">
-        <div className="w-24 h-24 rounded-2xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-lg">
+    <div className="p-3 h-full flex flex-col gap-3">
+      {/* Main Content Row */}
+      <div className="flex items-center gap-3 flex-1">
+        {/* Cover Image - Left Side */}
+        <div className="w-16 h-16 rounded-lg overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-md flex-shrink-0">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -40,72 +41,62 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-12 h-12 text-white" />
+              <MusicIcon className="w-8 h-8 text-white" />
             </div>
           )}
         </div>
-      </div>
 
-      {/* Track Name */}
-      <div className="text-center mb-4">
-        <h4 className="font-medium text-gray-900 text-sm truncate px-2">
-          {currentTrack?.name || "Música Galáctica"}
-        </h4>
-      </div>
-
-      {/* Controls Row: Volume icon + Play button + Volume bar */}
-      <div className="mt-auto">
-        <div className="flex items-center gap-3">
-          {/* Volume Icon */}
-          <Volume2 className="w-4 h-4 text-blue-600 flex-shrink-0" />
-
-          {/* Minimalist Play Button */}
-          <motion.button
-            onClick={togglePlayPause}
-            className="w-7 h-7 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center flex-shrink-0"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-          >
-            {isPlaying ? (
-              <Pause className="w-3 h-3 text-white" />
-            ) : (
-              <Play className="w-3 h-3 text-white ml-0.5" />
-            )}
-          </motion.button>
-
-          {/* Super Luminous Volume Bar */}
-          <div className="flex-1 relative h-4 flex items-center">
-            <div className="w-full h-2 bg-gray-200 rounded-full shadow-inner">
-              <div
-                className="h-full bg-gradient-to-r from-blue-400 to-cyan-400 rounded-full transition-all duration-300"
-                style={{
-                  width: `${volume * 100}%`,
-                  boxShadow: `
-                    0 0 8px rgba(59, 130, 246, 1),
-                    0 0 16px rgba(59, 130, 246, 0.8),
-                    0 0 24px rgba(59, 130, 246, 0.6),
-                    inset 0 1px 2px rgba(255, 255, 255, 0.3)
-                  `,
-                  filter: "brightness(1.3) saturate(1.2)",
-                }}
-              ></div>
-            </div>
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.05"
-              value={volume}
-              onChange={(e) => setVolume(Number(e.target.value))}
-              className="absolute inset-0 w-full opacity-0 cursor-pointer"
-            />
-          </div>
-
-          {/* Volume Percentage */}
-          <span className="text-xs text-blue-700 font-semibold w-8 text-center">
-            {Math.round(volume * 100)}%
-          </span>
+        {/* Track Info - Right Side */}
+        <div className="flex-1 min-w-0">
+          <h4 className="font-medium text-gray-900 text-sm truncate mb-1">
+            {currentTrack?.name || "Música Galáctica"}
+          </h4>
+          <p className="text-xs text-gray-500">XenoPets</p>
         </div>
+      </div>
+
+      {/* Controls Row - Bottom */}
+      <div className="flex items-center gap-2">
+        <Volume2 className="w-4 h-4 text-blue-600 flex-shrink-0" />
+
+        <motion.button
+          onClick={togglePlayPause}
+          className="w-6 h-6 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors flex items-center justify-center flex-shrink-0"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          {isPlaying ? (
+            <Pause className="w-3 h-3 text-white" />
+          ) : (
+            <Play className="w-3 h-3 text-white ml-0.5" />
+          )}
+        </motion.button>
+
+        <div className="flex-1 relative">
+          <div className="w-full h-1.5 bg-gray-200 rounded-full">
+            <div
+              className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-300"
+              style={{
+                width: `${volume * 100}%`,
+                boxShadow: `0 0 6px rgba(59, 130, 246, 1), 0 0 12px rgba(59, 130, 246, 0.7)`,
+                filter: "brightness(1.2)",
+              }}
+            ></div>
+          </div>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            value={volume}
+            onChange={(e) => setVolume(Number(e.target.value))}
+            className="absolute inset-0 w-full opacity-0 cursor-pointer"
+          />
+        </div>
+
+        <span className="text-xs text-blue-700 font-medium w-7 text-center flex-shrink-0">
+          {Math.round(volume * 100)}%
+        </span>
       </div>
     </div>
   );

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -19,8 +19,8 @@ export const MusicModal: React.FC = () => {
     <div className="p-3 h-full flex flex-col gap-3">
       {/* Main Content Row */}
       <div className="flex items-center gap-3 flex-1">
-        {/* Cover Image - Left Side */}
-        <div className="w-16 h-16 rounded-lg overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-md flex-shrink-0">
+        {/* Cover Image - Left Side - Larger */}
+        <div className="w-20 h-20 rounded-lg overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-md flex-shrink-0">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,96 +24,89 @@ export const MusicModal: React.FC = () => {
   };
 
   return (
-    <div className="p-6 h-full flex flex-col justify-center items-center">
-      {/* Cover Image */}
-      <div className="w-40 h-40 rounded-3xl mb-6 shadow-2xl relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
-        {currentTrack?.coverImage ? (
-          <>
+    <div className="flex flex-col h-full p-4">
+      {/* Cover Image - Compact */}
+      <div className="flex items-center justify-center mb-4">
+        <div className="w-24 h-24 rounded-2xl shadow-lg relative overflow-hidden bg-gradient-to-br from-blue-500 via-purple-500 to-indigo-600">
+          {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
               alt={currentTrack.name}
               className="w-full h-full object-cover"
               onError={(e) => {
-                // Fallback to gradient background
-                e.currentTarget.style.display = "none";
+                const target = e.target as HTMLImageElement;
+                target.style.display = "none";
               }}
             />
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 to-black/20"></div>
-          </>
-        ) : (
-          <>
-            <div className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"></div>
+          ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-20 h-20 text-white z-10" />
+              <MusicIcon className="w-12 h-12 text-white" />
             </div>
-          </>
-        )}
-        {isPlaying && (
-          <div className="absolute bottom-2 right-2 w-3 h-3 bg-green-400 rounded-full shadow-lg animate-pulse"></div>
-        )}
+          )}
+          {isPlaying && (
+            <div className="absolute top-1 right-1 w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
+          )}
+        </div>
       </div>
 
-      {/* Track Info */}
-      <div className="text-center mb-8">
-        <h4 className="font-bold text-gray-900 mb-2 text-xl">
+      {/* Track Info - Compact */}
+      <div className="text-center mb-4">
+        <h4 className="font-semibold text-gray-900 text-base leading-tight mb-1 truncate">
           {currentTrack?.name || "Música Galáctica"}
         </h4>
-        <p className="text-sm text-gray-600 font-medium">XenoPets Soundtrack</p>
+        <p className="text-xs text-gray-500">XenoPets</p>
       </div>
 
-      {/* Play/Pause Control */}
-      <div className="mb-8">
+      {/* Play/Pause Control - Compact */}
+      <div className="flex justify-center mb-4">
         <motion.button
           onClick={togglePlayPause}
-          className="p-4 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-lg"
-          whileHover={{ scale: 1.1 }}
-          whileTap={{ scale: 0.9 }}
+          className="w-12 h-12 rounded-full bg-blue-500 hover:bg-blue-600 transition-colors shadow-md flex items-center justify-center"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
         >
           {isPlaying ? (
-            <Pause className="w-8 h-8 text-white" />
+            <Pause className="w-5 h-5 text-white" />
           ) : (
-            <Play className="w-8 h-8 text-white ml-1" />
+            <Play className="w-5 h-5 text-white ml-0.5" />
           )}
         </motion.button>
       </div>
 
-      {/* Volume Control */}
-      <div className="w-full max-w-xs">
-        <div className="flex items-center justify-between mb-3">
-          <span className="text-sm font-medium text-gray-700">Volume</span>
-          <span className="text-sm text-blue-600 font-semibold">
+      {/* Volume Control - Compact */}
+      <div className="flex-1 flex flex-col justify-end">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs font-medium text-gray-600">Volume</span>
+          <span className="text-xs text-blue-600 font-semibold">
             {Math.round(volume * 100)}%
           </span>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
           {volume === 0 ? (
-            <VolumeX className="w-5 h-5 text-gray-400" />
+            <VolumeX className="w-4 h-4 text-gray-400 flex-shrink-0" />
           ) : (
-            <Volume2 className="w-5 h-5 text-blue-600" />
+            <Volume2 className="w-4 h-4 text-blue-600 flex-shrink-0" />
           )}
           <div className="flex-1 relative">
-            <div className="relative">
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.05"
-                value={volume}
-                onChange={(e) => setVolume(Number(e.target.value))}
-                className="w-full h-4 bg-gray-200 rounded-full appearance-none cursor-pointer slider-luminous"
-                style={{
-                  background: `linear-gradient(to right, #2563eb 0%, #3b82f6 ${volume * 50}%, #60a5fa ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
-                }}
-              />
-              <div
-                className="absolute top-0 left-0 h-4 bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full pointer-events-none transition-all duration-200"
-                style={{
-                  width: `${volume * 100}%`,
-                  boxShadow: `0 0 20px rgba(59, 130, 246, ${volume * 0.8}), 0 0 40px rgba(59, 130, 246, ${volume * 0.4})`,
-                  filter: `brightness(${1 + volume * 0.5})`,
-                }}
-              ></div>
-            </div>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={volume}
+              onChange={(e) => setVolume(Number(e.target.value))}
+              className="w-full h-2 bg-gray-200 rounded-full appearance-none cursor-pointer slider-luminous"
+              style={{
+                background: `linear-gradient(to right, #3b82f6 0%, #60a5fa ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
+              }}
+            />
+            <div
+              className="absolute top-0 left-0 h-2 bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full pointer-events-none transition-all duration-200"
+              style={{
+                width: `${volume * 100}%`,
+                boxShadow: `0 0 8px rgba(59, 130, 246, ${volume * 0.6})`,
+              }}
+            ></div>
           </div>
         </div>
       </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,109 +24,70 @@ export const MusicModal: React.FC = () => {
   } = useMusicContext();
 
   return (
-    <div className="p-6 h-full flex flex-col">
-      {/* Welcome message */}
-      <div className="flex items-center gap-3 mb-6">
-        <div className="p-2 bg-blue-100 rounded-lg">
-          <MusicIcon className="w-5 h-5 text-blue-600" />
-        </div>
-        <div>
-          <p className="text-sm text-gray-600">
-            Olá, {user?.username || "Jogador"}!
-          </p>
-        </div>
+    <div className="p-6 h-full flex flex-col justify-center items-center">
+      {/* Cover Image */}
+      <div className="w-32 h-32 bg-gradient-to-br from-blue-400 via-blue-500 to-purple-600 rounded-2xl mb-6 flex items-center justify-center shadow-lg">
+        <MusicIcon className="w-16 h-16 text-white" />
       </div>
 
-      {/* Music Player Content */}
-      <div className="flex-1 flex flex-col justify-center">
-        {/* Track Info */}
-        <div className="text-center mb-6">
-          <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-purple-500 rounded-full mx-auto mb-3 flex items-center justify-center">
-            <MusicIcon className="w-8 h-8 text-white" />
-          </div>
-          <h4 className="font-medium text-gray-900 mb-1">
-            {currentTrack?.name || "Música Galáctica"}
-          </h4>
-          <p className="text-sm text-gray-600">XenoPets Soundtrack</p>
+      {/* Track Info */}
+      <div className="text-center mb-8">
+        <h4 className="font-semibold text-gray-900 mb-1 text-lg">
+          {currentTrack?.name || "Música Galáctica"}
+        </h4>
+        <p className="text-sm text-gray-600">XenoPets Soundtrack</p>
+        <p className="text-xs text-gray-500 mt-2">
+          Olá, {user?.username || "Jogador"}!
+        </p>
+      </div>
+
+      {/* Play/Pause Control */}
+      <div className="mb-8">
+        <motion.button
+          onClick={togglePlayPause}
+          disabled={isLoading}
+          className="p-4 rounded-full bg-blue-500 hover:bg-blue-600 disabled:opacity-50 transition-colors shadow-lg"
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+        >
+          {isLoading ? (
+            <div className="w-8 h-8 border-3 border-white border-t-transparent rounded-full animate-spin" />
+          ) : isPlaying ? (
+            <Pause className="w-8 h-8 text-white" />
+          ) : (
+            <Play className="w-8 h-8 text-white ml-1" />
+          )}
+        </motion.button>
+      </div>
+
+      {/* Volume Control */}
+      <div className="w-full max-w-xs">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-sm font-medium text-gray-700">Volume</span>
+          <span className="text-sm text-blue-600 font-semibold">
+            {Math.round(volume * 100)}%
+          </span>
         </div>
-
-        {/* Controls */}
-        <div className="flex items-center justify-center gap-4 mb-6">
-          <motion.button
-            onClick={previousTrack}
-            className="p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors"
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
-          >
-            <svg
-              className="w-5 h-5 text-gray-600"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path d="M8.445 14.832A1 1 0 0 0 10 14v-2.798l5.445 3.63A1 1 0 0 0 17 14V6a1 1 0 0 0-1.555-.832L10 8.798V6a1 1 0 0 0-1.555-.832l-6 4a1 1 0 0 0 0 1.664l6 4z" />
-            </svg>
-          </motion.button>
-
-          <motion.button
-            onClick={togglePlayPause}
-            disabled={isLoading}
-            className="p-3 rounded-full bg-blue-500 hover:bg-blue-600 disabled:opacity-50 transition-colors"
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
-          >
-            {isLoading ? (
-              <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
-            ) : isPlaying ? (
-              <Pause className="w-6 h-6 text-white" />
-            ) : (
-              <Play className="w-6 h-6 text-white ml-1" />
-            )}
-          </motion.button>
-
-          <motion.button
-            onClick={nextTrack}
-            className="p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors"
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.9 }}
-          >
-            <svg
-              className="w-5 h-5 text-gray-600"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path d="M4.555 5.168A1 1 0 0 0 3 6v8a1 1 0 0 0 1.555.832L10 11.202V14a1 1 0 0 0 1.555.832l6-4a1 1 0 0 0 0-1.664l-6-4A1 1 0 0 0 10 6v2.798L4.555 5.168z" />
-            </svg>
-          </motion.button>
-        </div>
-
-        {/* Volume Control */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-700">Volume</span>
-            <span className="text-sm text-gray-500">
-              {Math.round(volume * 100)}%
-            </span>
-          </div>
-          <div className="flex items-center gap-3">
-            {volume === 0 ? (
-              <VolumeX className="w-4 h-4 text-gray-400" />
-            ) : (
-              <Volume2 className="w-4 h-4 text-gray-600" />
-            )}
-            <div className="flex-1">
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={volume}
-                onChange={(e) => setVolume(Number(e.target.value))}
-                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                style={{
-                  background: `linear-gradient(to right, #3b82f6 0%, #3b82f6 ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
-                }}
-              />
-            </div>
+        <div className="flex items-center gap-3">
+          {volume === 0 ? (
+            <VolumeX className="w-5 h-5 text-gray-400" />
+          ) : (
+            <Volume2 className="w-5 h-5 text-blue-600" />
+          )}
+          <div className="flex-1 relative">
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={volume}
+              onChange={(e) => setVolume(Number(e.target.value))}
+              className="w-full h-3 bg-gray-200 rounded-full appearance-none cursor-pointer"
+              style={{
+                background: `linear-gradient(to right, #3b82f6 0%, #60a5fa ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
+                boxShadow: `0 0 10px rgba(59, 130, 246, ${volume * 0.5})`,
+              }}
+            />
           </div>
         </div>
       </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -62,10 +62,15 @@ export const MusicModal: React.FC = () => {
           )}
         </button>
 
-        <div className="flex-1 relative">
+        <div
+          className="flex-1 relative"
+          onMouseDown={(e) => e.stopPropagation()}
+          onTouchStart={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
           <div className="w-full h-1.5 bg-gray-200 rounded-full">
             <div
-              className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-300"
+              className="h-full bg-gradient-to-r from-blue-500 to-cyan-400 rounded-full transition-all duration-300 pointer-events-none"
               style={{
                 width: `${volume * 100}%`,
                 boxShadow: `0 0 6px rgba(59, 130, 246, 1), 0 0 12px rgba(59, 130, 246, 0.7)`,
@@ -83,9 +88,24 @@ export const MusicModal: React.FC = () => {
               e.stopPropagation();
               setVolume(Number(e.target.value));
             }}
-            onMouseDown={(e) => e.stopPropagation()}
-            onTouchStart={(e) => e.stopPropagation()}
-            className="absolute inset-0 w-full opacity-0 cursor-pointer"
+            onMouseDown={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            onTouchStart={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            onDragStart={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+            className="absolute inset-0 w-full opacity-0 cursor-pointer z-10"
+            style={{ touchAction: "none" }}
           />
         </div>
 

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -24,14 +24,13 @@ export const MusicModal: React.FC = () => {
   } = useMusicContext();
 
   return (
-    <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center gap-3 p-4 border-b border-gray-100 bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg">
+    <div className="p-6 h-full flex flex-col">
+      {/* Welcome message */}
+      <div className="flex items-center gap-3 mb-6">
         <div className="p-2 bg-blue-100 rounded-lg">
           <MusicIcon className="w-5 h-5 text-blue-600" />
         </div>
         <div>
-          <h3 className="font-semibold text-gray-900">Player de Música</h3>
           <p className="text-sm text-gray-600">
             Olá, {user?.username || "Jogador"}!
           </p>
@@ -39,7 +38,7 @@ export const MusicModal: React.FC = () => {
       </div>
 
       {/* Music Player Content */}
-      <div className="px-2">
+      <div className="flex-1 flex flex-col justify-center">
         {/* Track Info */}
         <div className="text-center mb-6">
           <div className="w-16 h-16 bg-gradient-to-br from-blue-400 to-purple-500 rounded-full mx-auto mb-3 flex items-center justify-center">

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -12,16 +12,8 @@ import { useMusicContext } from "../../contexts/MusicContext";
 
 export const MusicModal: React.FC = () => {
   const { user } = useGameStore();
-  const { isPlaying, currentTrack, volume, setVolume, play, pause } =
+  const { isPlaying, currentTrack, volume, setVolume, togglePlayPause } =
     useMusicContext();
-
-  const togglePlayPause = () => {
-    if (isPlaying) {
-      pause();
-    } else {
-      play();
-    }
-  };
 
   return (
     <div className="p-3 h-full flex flex-col gap-3">

--- a/src/components/Layout/NotificationsModal.tsx
+++ b/src/components/Layout/NotificationsModal.tsx
@@ -62,7 +62,7 @@ export const NotificationsModal: React.FC = () => {
           notifications.map((notification) => (
             <motion.div
               key={notification.id}
-              className={`p-4 border-b border-gray-50 cursor-pointer hover:bg-gray-25 transition-colors ${
+              className={`p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors ${
                 notification.isRead ? "opacity-60" : ""
               }`}
               onClick={() => handleNotificationClick(notification.id)}

--- a/src/components/Layout/NotificationsModal.tsx
+++ b/src/components/Layout/NotificationsModal.tsx
@@ -36,10 +36,13 @@ export const NotificationsModal: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-100">
-        <h3 className="font-semibold text-gray-900">Notificações</h3>
+    <div className="p-4 h-full flex flex-col">
+      {/* Header with clear all button */}
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm text-gray-600">
+          {notifications.length} notificação
+          {notifications.length !== 1 ? "s" : ""}
+        </span>
         <button
           onClick={() => clearNotifications()}
           className="p-2 hover:bg-gray-50 rounded-full transition-colors"
@@ -50,7 +53,7 @@ export const NotificationsModal: React.FC = () => {
       </div>
 
       {/* Notification List */}
-      <div className="overflow-y-auto flex-1 max-h-96">
+      <div className="flex-1 space-y-2">
         {notifications.length === 0 ? (
           <div className="p-6 text-center text-gray-500">
             <p>Nenhuma notificação</p>

--- a/src/components/Layout/NotificationsModal.tsx
+++ b/src/components/Layout/NotificationsModal.tsx
@@ -36,9 +36,9 @@ export const NotificationsModal: React.FC = () => {
   };
 
   return (
-    <div className="w-80 max-w-[calc(100vw-3rem)] bg-white rounded-2xl shadow-xl border border-gray-100 max-h-[70vh] flex flex-col overflow-hidden">
+    <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-50">
+      <div className="flex items-center justify-between p-4 border-b border-gray-100">
         <h3 className="font-semibold text-gray-900">Notificações</h3>
         <button
           onClick={() => clearNotifications()}
@@ -50,7 +50,7 @@ export const NotificationsModal: React.FC = () => {
       </div>
 
       {/* Notification List */}
-      <div className="overflow-y-auto flex-1">
+      <div className="overflow-y-auto flex-1 max-h-96">
         {notifications.length === 0 ? (
           <div className="p-6 text-center text-gray-500">
             <p>Nenhuma notificação</p>

--- a/src/hooks/useBackgroundMusic.ts
+++ b/src/hooks/useBackgroundMusic.ts
@@ -67,6 +67,14 @@ export const useBackgroundMusic = (): UseBackgroundMusicReturn => {
     updateState();
   }, [updateState]);
 
+  const togglePlayPause = useCallback(async () => {
+    if (isPlaying) {
+      await pause();
+    } else {
+      await play();
+    }
+  }, [isPlaying, play, pause]);
+
   const setVolume = useCallback(
     (newVolume: number) => {
       console.log("🔊 Hook: Mudando volume para:", newVolume);

--- a/src/hooks/useBackgroundMusic.ts
+++ b/src/hooks/useBackgroundMusic.ts
@@ -14,6 +14,7 @@ export interface UseBackgroundMusicReturn {
   play: () => Promise<void>;
   pause: () => Promise<void>;
   stop: () => Promise<void>;
+  togglePlayPause: () => Promise<void>;
   nextTrack: () => Promise<void>;
   previousTrack: () => Promise<void>;
   setVolume: (volume: number) => void;

--- a/src/hooks/useBackgroundMusic.ts
+++ b/src/hooks/useBackgroundMusic.ts
@@ -155,6 +155,7 @@ export const useBackgroundMusic = (): UseBackgroundMusicReturn => {
     play,
     pause,
     stop,
+    togglePlayPause,
     nextTrack,
     previousTrack,
     setVolume,

--- a/src/index.css
+++ b/src/index.css
@@ -176,6 +176,44 @@ canvas {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
+/* Luminous volume slider styles */
+.slider-luminous::-webkit-slider-thumb {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, #3b82f6, #60a5fa);
+  cursor: pointer;
+  border: 3px solid white;
+  box-shadow:
+    0 0 15px rgba(59, 130, 246, 0.8),
+    0 0 30px rgba(59, 130, 246, 0.4);
+  position: relative;
+  z-index: 10;
+}
+
+.slider-luminous::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, #3b82f6, #60a5fa);
+  cursor: pointer;
+  border: 3px solid white;
+  box-shadow:
+    0 0 15px rgba(59, 130, 246, 0.8),
+    0 0 30px rgba(59, 130, 246, 0.4);
+}
+
+.slider-luminous::-webkit-slider-track {
+  background: transparent;
+  border-radius: 8px;
+}
+
+.slider-luminous::-moz-range-track {
+  background: transparent;
+  border-radius: 8px;
+}
+
 /* Touch-friendly input ranges */
 input[type="range"] {
   touch-action: manipulation;


### PR DESCRIPTION
This PR refactors modal screen redirects and redesigns the music player component.

**Modal Redirect Changes:**
- Move modal redirect logic from switch case to dedicated useEffect hook
- Simplify switch case to show SpaceMap while redirect is processing
- Improve separation of concerns for authentication-based redirects

**Music Player Redesign:**
- Convert to compact minimalist design (300x250px)
- Remove modal header and use floating close button
- Redesign layout with horizontal arrangement of cover art and controls
- Add luminous volume slider with gradient styling
- Remove previous/next track buttons for simplified interface
- Add togglePlayPause function to music hook

**Modal System Updates:**
- Add conditional header rendering in DraggableModal
- Support headerless modals with floating close button
- Update music modal size and remove title
- Improve notifications modal layout and styling

**CSS Additions:**
- Add luminous slider styles with glowing effects
- Improve webkit and moz slider thumb styling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fc4d1f08d8ac4a43ae466f14ec4ce8fd/quantum-zone)

👀 [Preview Link](https://fc4d1f08d8ac4a43ae466f14ec4ce8fd-quantum-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fc4d1f08d8ac4a43ae466f14ec4ce8fd</projectId>-->
<!--<branchName>quantum-zone</branchName>-->