### PR TITLE
Update music modal layout and styling

### DIFF
--- a/src/components/Audio/MusicMiniModal.tsx
+++ b/src/components/Audio/MusicMiniModal.tsx
@@ -101,9 +101,9 @@ export const MusicMiniModal: React.FC<MusicMiniModalProps> = ({
             </button>
           </div>
 
-          {/* Album Cover - Centered and Larger */}
-          <div className="flex flex-col items-center gap-4 mb-4">
-            <div className="relative w-28 h-28 rounded-2xl overflow-hidden shadow-lg flex-shrink-0">
+          {/* Album Cover and Info - Side by side */}
+          <div className="flex items-center gap-4 mb-4">
+            <div className="relative w-24 h-24 rounded-2xl overflow-hidden shadow-lg flex-shrink-0">
               <img
                 src={coverImage}
                 alt={currentTrack?.name || "Trilha Sonora"}
@@ -112,18 +112,17 @@ export const MusicMiniModal: React.FC<MusicMiniModalProps> = ({
               <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent" />
             </div>
 
-            {/* Track Info - Centered */}
-            <div className="text-center">
-              <h4 className="font-medium text-gray-900 text-base mb-1">
-                {currentTrack?.name || "Nenhuma música"}
-              </h4>
-              <p className="text-sm text-gray-600">{getScreenTitle()}</p>
-            </div>
+            {/* Track Info and Controls - Next to image */}
+            <div className="flex-1 min-w-0">
+              <div className="mb-3">
+                <h4 className="font-medium text-gray-900 text-base mb-1 truncate">
+                  {currentTrack?.name || "Nenhuma música"}
+                </h4>
+                <p className="text-sm text-gray-600">{getScreenTitle()}</p>
+              </div>
 
-            {/* Controls - Centered */}
-            <div className="w-full">
-              <div className="flex items-center justify-center gap-4 mb-3">
-                {/* Play/Pause Button */}
+              {/* Play/Pause Button */}
+              <div className="flex items-center gap-3 mb-3">
                 <motion.button
                   onClick={handlePlayPause}
                   className="bg-blue-500 hover:bg-blue-600 text-white rounded-full p-2 transition-colors shadow-md"
@@ -138,8 +137,8 @@ export const MusicMiniModal: React.FC<MusicMiniModalProps> = ({
                 </motion.button>
               </div>
 
-              {/* Volume Control - Full width */}
-              <div className="flex items-center gap-3">
+              {/* Volume Control */}
+              <div className="flex items-center gap-2">
                 <button
                   onClick={handleMuteToggle}
                   className="p-1 hover:bg-gray-100 rounded-full transition-colors"

--- a/src/components/Audio/MusicMiniModal.tsx
+++ b/src/components/Audio/MusicMiniModal.tsx
@@ -102,8 +102,8 @@ export const MusicMiniModal: React.FC<MusicMiniModalProps> = ({
           </div>
 
           {/* Album Cover and Info - Side by side */}
-          <div className="flex items-center gap-4 mb-4">
-            <div className="relative w-24 h-24 rounded-2xl overflow-hidden shadow-lg flex-shrink-0">
+          <div className="flex items-center justify-center gap-6 mb-4">
+            <div className="relative w-28 h-28 rounded-2xl overflow-hidden shadow-lg flex-shrink-0">
               <img
                 src={coverImage}
                 alt={currentTrack?.name || "Trilha Sonora"}

--- a/src/components/Audio/MusicMiniModal.tsx
+++ b/src/components/Audio/MusicMiniModal.tsx
@@ -101,9 +101,9 @@ export const MusicMiniModal: React.FC<MusicMiniModalProps> = ({
             </button>
           </div>
 
-          {/* Album Cover - Larger size */}
-          <div className="flex items-center gap-4 mb-4">
-            <div className="relative w-20 h-20 rounded-xl overflow-hidden shadow-md flex-shrink-0">
+          {/* Album Cover - Centered and Larger */}
+          <div className="flex flex-col items-center gap-4 mb-4">
+            <div className="relative w-28 h-28 rounded-2xl overflow-hidden shadow-lg flex-shrink-0">
               <img
                 src={coverImage}
                 alt={currentTrack?.name || "Trilha Sonora"}
@@ -112,17 +112,18 @@ export const MusicMiniModal: React.FC<MusicMiniModalProps> = ({
               <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent" />
             </div>
 
-            {/* Track Info and Controls */}
-            <div className="flex-1 min-w-0">
-              <div className="mb-2">
-                <h4 className="font-medium text-gray-900 text-sm truncate">
-                  {currentTrack?.name || "Nenhuma música"}
-                </h4>
-                <p className="text-xs text-gray-600">{getScreenTitle()}</p>
-              </div>
+            {/* Track Info - Centered */}
+            <div className="text-center">
+              <h4 className="font-medium text-gray-900 text-base mb-1">
+                {currentTrack?.name || "Nenhuma música"}
+              </h4>
+              <p className="text-sm text-gray-600">{getScreenTitle()}</p>
+            </div>
 
-              {/* Play/Pause Button */}
-              <div className="flex items-center gap-3">
+            {/* Controls - Centered */}
+            <div className="w-full">
+              <div className="flex items-center justify-center gap-4 mb-3">
+                {/* Play/Pause Button */}
                 <motion.button
                   onClick={handlePlayPause}
                   className="bg-blue-500 hover:bg-blue-600 text-white rounded-full p-2 transition-colors shadow-md"
@@ -135,38 +136,38 @@ export const MusicMiniModal: React.FC<MusicMiniModalProps> = ({
                     <Play className="w-4 h-4 ml-0.5" />
                   )}
                 </motion.button>
+              </div>
 
-                {/* Volume Control */}
-                <div className="flex items-center gap-2 flex-1">
-                  <button
-                    onClick={handleMuteToggle}
-                    className="p-1 hover:bg-gray-100 rounded-full transition-colors"
-                  >
-                    {volume === 0 ? (
-                      <VolumeX className="w-4 h-4 text-gray-600" />
-                    ) : (
-                      <Volume2 className="w-4 h-4 text-gray-600" />
-                    )}
-                  </button>
+              {/* Volume Control - Full width */}
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={handleMuteToggle}
+                  className="p-1 hover:bg-gray-100 rounded-full transition-colors"
+                >
+                  {volume === 0 ? (
+                    <VolumeX className="w-4 h-4 text-gray-600" />
+                  ) : (
+                    <Volume2 className="w-4 h-4 text-gray-600" />
+                  )}
+                </button>
 
-                  <div className="flex-1">
-                    <input
-                      type="range"
-                      min="0"
-                      max="100"
-                      value={volume * 100} // Convert from 0-1 to 0-100
-                      onChange={handleVolumeChange}
-                      className="w-full h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                      style={{
-                        background: `linear-gradient(to right, #3b82f6 0%, #3b82f6 ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
-                      }}
-                    />
-                  </div>
-
-                  <span className="text-xs text-gray-500 w-6 text-right">
-                    {Math.round(volume * 100)}
-                  </span>
+                <div className="flex-1">
+                  <input
+                    type="range"
+                    min="0"
+                    max="100"
+                    value={volume * 100} // Convert from 0-1 to 0-100
+                    onChange={handleVolumeChange}
+                    className="w-full h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    style={{
+                      background: `linear-gradient(to right, #3b82f6 0%, #3b82f6 ${volume * 100}%, #e5e7eb ${volume * 100}%, #e5e7eb 100%)`,
+                    }}
+                  />
                 </div>
+
+                <span className="text-xs text-gray-500 w-6 text-right">
+                  {Math.round(volume * 100)}
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -17,10 +17,10 @@ export const MusicModal: React.FC = () => {
 
   return (
     <div className="p-4 h-full flex flex-col gap-4">
-      {/* Main Content - Centered */}
-      <div className="flex flex-col items-center gap-3 flex-1">
-        {/* Cover Image - Centered and Larger */}
-        <div className="w-24 h-24 rounded-xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-lg flex-shrink-0">
+      {/* Main Content Row - Centered */}
+      <div className="flex items-center justify-center gap-4 flex-1">
+        {/* Cover Image - Larger */}
+        <div className="w-16 h-16 rounded-xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-lg flex-shrink-0">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -33,14 +33,14 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-12 h-12 text-white" />
+              <MusicIcon className="w-8 h-8 text-white" />
             </div>
           )}
         </div>
 
-        {/* Track Info - Centered */}
-        <div className="text-center">
-          <h4 className="font-medium text-gray-900 text-base mb-1">
+        {/* Track Info - Next to image */}
+        <div className="flex-1 min-w-0">
+          <h4 className="font-medium text-gray-900 text-base mb-1 truncate">
             {currentTrack?.name || "Música Galáctica"}
           </h4>
           <p className="text-sm text-gray-500">XenoPets</p>

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -16,11 +16,11 @@ export const MusicModal: React.FC = () => {
     useMusicContext();
 
   return (
-    <div className="p-3 h-full flex flex-col gap-3">
-      {/* Main Content Row */}
-      <div className="flex items-center gap-3 flex-1">
-        {/* Cover Image - Left Side - Larger */}
-        <div className="w-20 h-20 rounded-lg overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-md flex-shrink-0">
+    <div className="p-4 h-full flex flex-col gap-4">
+      {/* Main Content - Centered */}
+      <div className="flex flex-col items-center gap-3 flex-1">
+        {/* Cover Image - Centered and Larger */}
+        <div className="w-24 h-24 rounded-xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-lg flex-shrink-0">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -33,17 +33,17 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-10 h-10 text-white" />
+              <MusicIcon className="w-12 h-12 text-white" />
             </div>
           )}
         </div>
 
-        {/* Track Info - Right Side */}
-        <div className="flex-1 min-w-0">
-          <h4 className="font-medium text-gray-900 text-sm truncate mb-1">
+        {/* Track Info - Centered */}
+        <div className="text-center">
+          <h4 className="font-medium text-gray-900 text-base mb-1">
             {currentTrack?.name || "Música Galáctica"}
           </h4>
-          <p className="text-xs text-gray-500">XenoPets</p>
+          <p className="text-sm text-gray-500">XenoPets</p>
         </div>
       </div>
 

--- a/src/components/Layout/MusicModal.tsx
+++ b/src/components/Layout/MusicModal.tsx
@@ -18,9 +18,9 @@ export const MusicModal: React.FC = () => {
   return (
     <div className="p-4 h-full flex flex-col gap-4">
       {/* Main Content Row - Centered */}
-      <div className="flex items-center justify-center gap-4 flex-1">
-        {/* Cover Image - Larger */}
-        <div className="w-16 h-16 rounded-xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-lg flex-shrink-0">
+      <div className="flex items-center justify-center gap-6 flex-1">
+        {/* Cover Image - Much Larger */}
+        <div className="w-20 h-20 rounded-xl overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900 shadow-lg flex-shrink-0">
           {currentTrack?.coverImage ? (
             <img
               src={currentTrack.coverImage}
@@ -33,7 +33,7 @@ export const MusicModal: React.FC = () => {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">
-              <MusicIcon className="w-8 h-8 text-white" />
+              <MusicIcon className="w-10 h-10 text-white" />
             </div>
           )}
         </div>


### PR DESCRIPTION
Updates layout and styling for music modal components:

**MusicMiniModal.tsx:**
- Increased album cover size from 20x20 to 28x28 with rounded-2xl corners
- Enhanced shadow from shadow-md to shadow-lg
- Centered layout with justify-center and increased gap from 4 to 6
- Improved typography: track name from text-sm to text-base, subtitle from text-xs to text-sm
- Restructured volume controls layout with additional margin bottom
- Updated comments to reflect new side-by-side layout

**MusicModal.tsx:**
- Increased padding from p-3 to p-4 and gap from gap-3 to gap-4
- Centered main content with justify-center and increased gap from 3 to 6
- Enhanced album cover styling with rounded-xl and shadow-lg
- Improved typography: track name from text-sm to text-base, subtitle from text-xs to text-sm
- Updated comments for clarity

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c057711ef26842db9a3f214118e8a693/zen-oasis)

👀 [Preview Link](https://c057711ef26842db9a3f214118e8a693-zen-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c057711ef26842db9a3f214118e8a693</projectId>-->
<!--<branchName>zen-oasis</branchName>-->