### PR TITLE
Add Memory Crystals minigame and pet redirect logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,8 @@ function App() {
     currentScreen,
     currentPlanet,
     user: gameUser,
+    pets,
+    activePet,
     setUser,
     setCurrentScreen,
     setCurrentPlanet,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,6 +158,24 @@ function App() {
     }
   }, [isAuthenticated, currentScreen]);
 
+  // Redirect users without pets to Vila Ancestral
+  useEffect(() => {
+    if (
+      isAuthenticated &&
+      gameUser &&
+      pets.length === 0 &&
+      currentScreen !== "planet"
+    ) {
+      // Find Vila Ancestral planet and navigate there
+      setCurrentPlanet({
+        id: "planet-5",
+        name: "Vila Ancestral",
+        color: "#dda0dd",
+      });
+      setCurrentScreen("planet");
+    }
+  }, [isAuthenticated, gameUser, pets.length, currentScreen]);
+
   const renderScreen = useMemo(() => {
     console.log("🖥️ App.tsx renderScreen executado:", {
       currentScreen,

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -427,28 +427,6 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
             <div className="text-xs text-gray-600">Recorde</div>
           </div>
         </div>
-
-        {/* Debug buttons for testing */}
-        <div className="flex justify-center gap-2 mt-4">
-          <button
-            onClick={() => {
-              console.log("Start game button clicked");
-              setGameStatus("playing");
-            }}
-            className="px-3 py-1 bg-green-100 text-green-700 rounded text-sm"
-          >
-            Forçar Início
-          </button>
-          <button
-            onClick={() => {
-              console.log("Jump button clicked");
-              jump();
-            }}
-            className="px-3 py-1 bg-blue-100 text-blue-700 rounded text-sm"
-          >
-            Teste Pulo
-          </button>
-        </div>
       </div>
     </motion.div>
   );

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -29,10 +29,10 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
   const CANVAS_HEIGHT = 600;
   const BIRD_SIZE = 12; // Much smaller bird
   const PIPE_WIDTH = 50;
-  const PIPE_GAP = 220; // Much bigger gap between pipes
-  const GRAVITY = 0.2; // Much reduced gravity for very slow fall
-  const JUMP_FORCE = -5; // Gentler jump force
-  const PIPE_SPEED = 1; // Much slower pipe movement
+  const PIPE_GAP = 250; // Even bigger gap
+  const GRAVITY = 0.05; // Very minimal gravity - bird almost floats
+  const JUMP_FORCE = -3; // Very gentle jump force
+  const PIPE_SPEED = 0.8; // Even slower pipe movement
 
   // Game state
   const [bird, setBird] = useState<Bird>({

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -27,12 +27,12 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
   // Game constants
   const CANVAS_WIDTH = 400;
   const CANVAS_HEIGHT = 600;
-  const BIRD_SIZE = 16; // Smaller bird for easier navigation
+  const BIRD_SIZE = 12; // Much smaller bird
   const PIPE_WIDTH = 50;
-  const PIPE_GAP = 180; // Bigger gap between pipes
-  const GRAVITY = 0.3; // Reduced gravity for slower fall
-  const JUMP_FORCE = -6; // Slightly less jump force for better control
-  const PIPE_SPEED = 1.5; // Slower pipe movement
+  const PIPE_GAP = 220; // Much bigger gap between pipes
+  const GRAVITY = 0.2; // Much reduced gravity for very slow fall
+  const JUMP_FORCE = -5; // Gentler jump force
+  const PIPE_SPEED = 1; // Much slower pipe movement
 
   // Game state
   const [bird, setBird] = useState<Bird>({

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -499,7 +499,74 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
             <div className="font-semibold text-gray-800">{highScore}</div>
             <div className="text-xs text-gray-600">Recorde</div>
           </div>
+          <div className="text-center">
+            <div className="font-semibold text-gray-800">{dailyRewards}/3</div>
+            <div className="text-xs text-gray-600">Resgates Hoje</div>
+          </div>
         </div>
+
+        {/* Reward Options Overlay */}
+        {showRewardOptions && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+          >
+            <motion.div
+              initial={{ y: 20 }}
+              animate={{ y: 0 }}
+              className="bg-white rounded-2xl p-6 mx-4 max-w-sm w-full"
+            >
+              <div className="text-center mb-6">
+                <h3 className="text-xl font-bold text-gray-800 mb-2">
+                  Fim de Jogo!
+                </h3>
+                <p className="text-gray-600">Pontuação: {score}</p>
+                {score > 0 && (
+                  <p className="text-blue-600 text-sm">
+                    Potencial ganho: {score * 10} Xenocoins
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-3">
+                {canClaimReward ? (
+                  <motion.button
+                    onClick={claimXenocoins}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    className="w-full bg-blue-600 text-white py-3 px-4 rounded-lg font-medium flex items-center justify-center gap-2 hover:bg-blue-700 transition-colors"
+                  >
+                    <Coins className="w-5 h-5" />
+                    Resgatar {score * 10} Xenocoins
+                  </motion.button>
+                ) : (
+                  <div className="w-full bg-gray-100 text-gray-500 py-3 px-4 rounded-lg font-medium text-center">
+                    {dailyRewards >= 3
+                      ? "Limite diário atingido (3/3)"
+                      : "Sem pontuação para resgatar"}
+                  </div>
+                )}
+
+                <motion.button
+                  onClick={tryAgain}
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  className="w-full bg-gray-600 text-white py-3 px-4 rounded-lg font-medium flex items-center justify-center gap-2 hover:bg-gray-700 transition-colors"
+                >
+                  <RefreshCw className="w-5 h-5" />
+                  Tentar Novamente
+                </motion.button>
+              </div>
+
+              {dailyRewards < 3 && (
+                <div className="mt-4 text-center text-sm text-gray-500">
+                  Resgates restantes hoje: {3 - dailyRewards}
+                </div>
+              )}
+            </motion.div>
+          </motion.div>
+        )}
       </div>
     </motion.div>
   );

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -53,7 +53,7 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
   // Initialize game
   const initGame = useCallback(() => {
     setBird({ x: 100, y: CANVAS_HEIGHT / 2, velocity: 0 });
-    setPipes([{ x: CANVAS_WIDTH + 100, height: 200, passed: false }]);
+    setPipes([{ x: CANVAS_WIDTH + 200, height: 250, passed: false }]); // Start further away with safe height
     setScore(0);
     setGameStatus("waiting");
   }, []);

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -84,8 +84,8 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
 
   // Generate new pipe
   const generatePipe = useCallback((x: number): Pipe => {
-    const minHeight = 100;
-    const maxHeight = CANVAS_HEIGHT - PIPE_GAP - minHeight;
+    const minHeight = 120; // More space at top
+    const maxHeight = CANVAS_HEIGHT - PIPE_GAP - 120; // More space at bottom
     const height = Math.random() * (maxHeight - minHeight) + minHeight;
     return { x, height, passed: false };
   }, []);

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -84,8 +84,8 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
 
   // Generate new pipe
   const generatePipe = useCallback((x: number): Pipe => {
-    const minHeight = 120; // More space at top
-    const maxHeight = CANVAS_HEIGHT - PIPE_GAP - 120; // More space at bottom
+    const minHeight = 150; // Much more space at top
+    const maxHeight = CANVAS_HEIGHT - PIPE_GAP - 150; // Much more space at bottom
     const height = Math.random() * (maxHeight - minHeight) + minHeight;
     return { x, height, passed: false };
   }, []);

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -101,10 +101,19 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
     setBird((prev) => {
       const newBird = { ...prev };
       newBird.velocity += GRAVITY;
+
+      // Add velocity damping for more control
+      newBird.velocity *= 0.98;
+
+      // Limit maximum fall speed
+      if (newBird.velocity > 4) {
+        newBird.velocity = 4;
+      }
+
       newBird.y += newBird.velocity;
 
-      // Check boundaries
-      if (newBird.y < 0 || newBird.y > CANVAS_HEIGHT - BIRD_SIZE) {
+      // Check boundaries with some margin
+      if (newBird.y < -5 || newBird.y > CANVAS_HEIGHT - BIRD_SIZE + 5) {
         endGame();
         return prev;
       }

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -158,9 +158,9 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
 
       // Generate new pipes
       const lastPipe = newPipes[newPipes.length - 1];
-      if (!lastPipe || lastPipe.x < CANVAS_WIDTH - 250) {
-        // More spacing between pipes
-        newPipes.push(generatePipe(CANVAS_WIDTH));
+      if (!lastPipe || lastPipe.x < CANVAS_WIDTH - 300) {
+        // Much more spacing between pipes
+        newPipes.push(generatePipe(CANVAS_WIDTH + 100)); // Start new pipes further away
       }
 
       return newPipes;

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -100,20 +100,36 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
     // Update bird
     setBird((prev) => {
       const newBird = { ...prev };
+
+      // Add hover effect - bird naturally wants to stay in center
+      const centerY = CANVAS_HEIGHT / 2;
+      const distanceFromCenter = Math.abs(newBird.y - centerY);
+
+      // Apply gentle centering force
+      if (newBird.y > centerY) {
+        newBird.velocity -= 0.02; // Gentle upward force when below center
+      } else {
+        newBird.velocity += 0.02; // Gentle downward force when above center
+      }
+
+      // Apply minimal gravity
       newBird.velocity += GRAVITY;
 
-      // Add velocity damping for more control
-      newBird.velocity *= 0.98;
+      // Strong velocity damping for smooth movement
+      newBird.velocity *= 0.95;
 
-      // Limit maximum fall speed
-      if (newBird.velocity > 4) {
-        newBird.velocity = 4;
+      // Limit maximum speed (much lower)
+      if (newBird.velocity > 2) {
+        newBird.velocity = 2;
+      }
+      if (newBird.velocity < -2) {
+        newBird.velocity = -2;
       }
 
       newBird.y += newBird.velocity;
 
-      // Check boundaries with some margin
-      if (newBird.y < -5 || newBird.y > CANVAS_HEIGHT - BIRD_SIZE + 5) {
+      // Check boundaries with generous margin
+      if (newBird.y < -10 || newBird.y > CANVAS_HEIGHT - BIRD_SIZE + 10) {
         endGame();
         return prev;
       }

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -158,7 +158,8 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
 
       // Generate new pipes
       const lastPipe = newPipes[newPipes.length - 1];
-      if (!lastPipe || lastPipe.x < CANVAS_WIDTH - 200) {
+      if (!lastPipe || lastPipe.x < CANVAS_WIDTH - 250) {
+        // More spacing between pipes
         newPipes.push(generatePipe(CANVAS_WIDTH));
       }
 

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -103,27 +103,34 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
   // Reward functions
   const canClaimReward = dailyRewards < 3 && score > 0;
 
-  const claimXenocoins = useCallback(() => {
+  const claimXenocoins = useCallback(async () => {
     if (!canClaimReward) return;
 
     const rewardAmount = score * 10; // 10 xenocoins per point
-    addXenocoins(rewardAmount);
 
-    // Update daily rewards count
-    const today = new Date().toDateString();
-    const newCount = dailyRewards + 1;
-    setDailyRewards(newCount);
-    localStorage.setItem(
-      "memory-crystals-daily-rewards",
-      JSON.stringify({
-        date: today,
-        count: newCount,
-      }),
-    );
+    try {
+      const success = await updateCurrency("xenocoins", rewardAmount);
 
-    setShowRewardOptions(false);
-    initGame();
-  }, [canClaimReward, score, addXenocoins, dailyRewards, initGame]);
+      if (success) {
+        // Update daily rewards count
+        const today = new Date().toDateString();
+        const newCount = dailyRewards + 1;
+        setDailyRewards(newCount);
+        localStorage.setItem(
+          "memory-crystals-daily-rewards",
+          JSON.stringify({
+            date: today,
+            count: newCount,
+          }),
+        );
+
+        setShowRewardOptions(false);
+        initGame();
+      }
+    } catch (error) {
+      console.error("Failed to add xenocoins:", error);
+    }
+  }, [canClaimReward, score, updateCurrency, dailyRewards, initGame]);
 
   const tryAgain = useCallback(() => {
     setShowRewardOptions(false);

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -52,6 +52,21 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
     return saved ? parseInt(saved, 10) : 0;
   });
 
+  // Daily rewards tracking
+  const [dailyRewards, setDailyRewards] = useState(() => {
+    const today = new Date().toDateString();
+    const saved = localStorage.getItem("memory-crystals-daily-rewards");
+    if (saved) {
+      const data = JSON.parse(saved);
+      if (data.date === today) {
+        return data.count;
+      }
+    }
+    return 0;
+  });
+
+  const [showRewardOptions, setShowRewardOptions] = useState(false);
+
   // Initialize game
   const initGame = useCallback(() => {
     setBird({ x: 100, y: CANVAS_HEIGHT / 2, velocity: 0 });

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -24,7 +24,7 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>();
-  const { xenocoins, addXenocoins } = useGameStore();
+  const { xenocoins, updateCurrency } = useGameStore();
 
   // Game constants
   const CANVAS_WIDTH = 400;

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -24,6 +24,7 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>();
+  const { xenocoins, addXenocoins } = useGameStore();
 
   // Game constants
   const CANVAS_WIDTH = 400;

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -360,7 +360,7 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
       );
     }
 
-    if (gameStatus === "gameOver") {
+    if (gameStatus === "gameOver" && !showRewardOptions) {
       ctx.fillStyle = "rgba(0, 0, 0, 0.8)";
       ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
 

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -1,0 +1,434 @@
+import React, { useEffect, useState, useRef, useCallback } from "react";
+import { motion } from "framer-motion";
+import { ArrowLeft, RotateCcw, Play } from "lucide-react";
+
+interface GameState {
+  bird: { x: number; y: number; velocity: number };
+  pipes: Array<{ x: number; height: number; passed: boolean }>;
+  score: number;
+  gameStatus: "waiting" | "playing" | "gameOver";
+}
+
+interface MemoryCrystalsGameProps {
+  onBack: () => void;
+}
+
+export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
+  onBack,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const lastTimeRef = useRef<number>(0);
+
+  // Game constants
+  const CANVAS_WIDTH = 400;
+  const CANVAS_HEIGHT = 600;
+  const BIRD_SIZE = 20;
+  const PIPE_WIDTH = 50;
+  const PIPE_GAP = 150;
+  const GRAVITY = 0.5;
+  const JUMP_FORCE = -8;
+  const PIPE_SPEED = 2;
+
+  // Game state
+  const [gameState, setGameState] = useState<GameState>({
+    bird: { x: 100, y: CANVAS_HEIGHT / 2, velocity: 0 },
+    pipes: [],
+    score: 0,
+    gameStatus: "waiting",
+  });
+
+  const [highScore, setHighScore] = useState(() => {
+    const saved = localStorage.getItem("memory-crystals-high-score");
+    return saved ? parseInt(saved, 10) : 0;
+  });
+
+  // Generate a new pipe
+  const generatePipe = useCallback((x: number) => {
+    const minHeight = 100;
+    const maxHeight = CANVAS_HEIGHT - PIPE_GAP - minHeight;
+    const height = Math.random() * (maxHeight - minHeight) + minHeight;
+    return { x, height, passed: false };
+  }, []);
+
+  // Initialize game
+  const initGame = useCallback(() => {
+    setGameState({
+      bird: { x: 100, y: CANVAS_HEIGHT / 2, velocity: 0 },
+      pipes: [generatePipe(CANVAS_WIDTH)],
+      score: 0,
+      gameStatus: "waiting",
+    });
+  }, [generatePipe]);
+
+  // Start game
+  const startGame = useCallback(() => {
+    setGameState((prev) => ({ ...prev, gameStatus: "playing" }));
+  }, []);
+
+  // Jump
+  const jump = useCallback(() => {
+    if (gameState.gameStatus === "waiting") {
+      startGame();
+    }
+    if (gameState.gameStatus === "playing") {
+      setGameState((prev) => ({
+        ...prev,
+        bird: { ...prev.bird, velocity: JUMP_FORCE },
+      }));
+    }
+  }, [gameState.gameStatus, startGame]);
+
+  // Game over
+  const gameOver = useCallback(() => {
+    setGameState((prev) => {
+      const newHighScore = Math.max(prev.score, highScore);
+      if (newHighScore > highScore) {
+        setHighScore(newHighScore);
+        localStorage.setItem(
+          "memory-crystals-high-score",
+          newHighScore.toString(),
+        );
+      }
+      return { ...prev, gameStatus: "gameOver" };
+    });
+  }, [highScore]);
+
+  // Update game physics
+  const updateGame = useCallback(
+    (deltaTime: number) => {
+      if (gameState.gameStatus !== "playing") return;
+
+      setGameState((prev) => {
+        const newBird = { ...prev.bird };
+        const newPipes = [...prev.pipes];
+        let newScore = prev.score;
+
+        // Update bird physics
+        newBird.velocity += GRAVITY;
+        newBird.y += newBird.velocity;
+
+        // Check boundaries
+        if (newBird.y < 0 || newBird.y > CANVAS_HEIGHT - BIRD_SIZE) {
+          gameOver();
+          return prev;
+        }
+
+        // Update pipes
+        for (let i = newPipes.length - 1; i >= 0; i--) {
+          const pipe = newPipes[i];
+          pipe.x -= PIPE_SPEED;
+
+          // Remove pipes that are off screen
+          if (pipe.x + PIPE_WIDTH < 0) {
+            newPipes.splice(i, 1);
+            continue;
+          }
+
+          // Check if bird passed pipe
+          if (!pipe.passed && newBird.x > pipe.x + PIPE_WIDTH) {
+            pipe.passed = true;
+            newScore++;
+          }
+
+          // Collision detection
+          const birdLeft = newBird.x;
+          const birdRight = newBird.x + BIRD_SIZE;
+          const birdTop = newBird.y;
+          const birdBottom = newBird.y + BIRD_SIZE;
+
+          const pipeLeft = pipe.x;
+          const pipeRight = pipe.x + PIPE_WIDTH;
+
+          if (birdRight > pipeLeft && birdLeft < pipeRight) {
+            // Check collision with top pipe
+            if (birdTop < pipe.height) {
+              gameOver();
+              return prev;
+            }
+            // Check collision with bottom pipe
+            if (birdBottom > pipe.height + PIPE_GAP) {
+              gameOver();
+              return prev;
+            }
+          }
+        }
+
+        // Generate new pipes
+        const lastPipe = newPipes[newPipes.length - 1];
+        if (!lastPipe || lastPipe.x < CANVAS_WIDTH - 200) {
+          newPipes.push(generatePipe(CANVAS_WIDTH));
+        }
+
+        return {
+          bird: newBird,
+          pipes: newPipes,
+          score: newScore,
+          gameStatus: "playing",
+        };
+      });
+    },
+    [gameState.gameStatus, gameOver, generatePipe],
+  );
+
+  // Render game
+  const render = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // Clear canvas with gradient background
+    const gradient = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT);
+    gradient.addColorStop(0, "#1e3a8a");
+    gradient.addColorStop(1, "#3730a3");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    // Draw bird (crystal)
+    ctx.save();
+    ctx.translate(
+      gameState.bird.x + BIRD_SIZE / 2,
+      gameState.bird.y + BIRD_SIZE / 2,
+    );
+
+    // Crystal shape
+    ctx.fillStyle = "#60a5fa";
+    ctx.strokeStyle = "#3b82f6";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(0, -BIRD_SIZE / 2);
+    ctx.lineTo(BIRD_SIZE / 3, -BIRD_SIZE / 4);
+    ctx.lineTo(BIRD_SIZE / 2, 0);
+    ctx.lineTo(BIRD_SIZE / 3, BIRD_SIZE / 4);
+    ctx.lineTo(0, BIRD_SIZE / 2);
+    ctx.lineTo(-BIRD_SIZE / 3, BIRD_SIZE / 4);
+    ctx.lineTo(-BIRD_SIZE / 2, 0);
+    ctx.lineTo(-BIRD_SIZE / 3, -BIRD_SIZE / 4);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+
+    // Inner sparkle
+    ctx.fillStyle = "#bfdbfe";
+    ctx.beginPath();
+    ctx.arc(0, 0, 4, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.restore();
+
+    // Draw pipes (crystal formations)
+    gameState.pipes.forEach((pipe) => {
+      // Top pipe
+      const topPipeGradient = ctx.createLinearGradient(
+        pipe.x,
+        0,
+        pipe.x + PIPE_WIDTH,
+        0,
+      );
+      topPipeGradient.addColorStop(0, "#8b5cf6");
+      topPipeGradient.addColorStop(1, "#a855f7");
+      ctx.fillStyle = topPipeGradient;
+      ctx.fillRect(pipe.x, 0, PIPE_WIDTH, pipe.height);
+
+      // Bottom pipe
+      const bottomPipeGradient = ctx.createLinearGradient(
+        pipe.x,
+        pipe.height + PIPE_GAP,
+        pipe.x + PIPE_WIDTH,
+        CANVAS_HEIGHT,
+      );
+      bottomPipeGradient.addColorStop(0, "#8b5cf6");
+      bottomPipeGradient.addColorStop(1, "#a855f7");
+      ctx.fillStyle = bottomPipeGradient;
+      ctx.fillRect(
+        pipe.x,
+        pipe.height + PIPE_GAP,
+        PIPE_WIDTH,
+        CANVAS_HEIGHT - pipe.height - PIPE_GAP,
+      );
+
+      // Crystal edges
+      ctx.strokeStyle = "#7c3aed";
+      ctx.lineWidth = 2;
+      ctx.strokeRect(pipe.x, 0, PIPE_WIDTH, pipe.height);
+      ctx.strokeRect(
+        pipe.x,
+        pipe.height + PIPE_GAP,
+        PIPE_WIDTH,
+        CANVAS_HEIGHT - pipe.height - PIPE_GAP,
+      );
+    });
+
+    // Draw score
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "bold 24px Arial";
+    ctx.textAlign = "center";
+    ctx.fillText(`Cristais: ${gameState.score}`, CANVAS_WIDTH / 2, 50);
+
+    // Draw game status text
+    if (gameState.gameStatus === "waiting") {
+      ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
+      ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "bold 20px Arial";
+      ctx.fillText(
+        "Cristais da Memória",
+        CANVAS_WIDTH / 2,
+        CANVAS_HEIGHT / 2 - 60,
+      );
+      ctx.font = "16px Arial";
+      ctx.fillText(
+        "Clique para começar!",
+        CANVAS_WIDTH / 2,
+        CANVAS_HEIGHT / 2 - 20,
+      );
+      ctx.fillText(
+        "Evite as formações cristalinas",
+        CANVAS_WIDTH / 2,
+        CANVAS_HEIGHT / 2 + 10,
+      );
+    }
+
+    if (gameState.gameStatus === "gameOver") {
+      ctx.fillStyle = "rgba(0, 0, 0, 0.8)";
+      ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "bold 24px Arial";
+      ctx.fillText("Fim de Jogo!", CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 - 40);
+      ctx.font = "18px Arial";
+      ctx.fillText(
+        `Pontuação: ${gameState.score}`,
+        CANVAS_WIDTH / 2,
+        CANVAS_HEIGHT / 2,
+      );
+      ctx.fillText(
+        `Recorde: ${highScore}`,
+        CANVAS_WIDTH / 2,
+        CANVAS_HEIGHT / 2 + 30,
+      );
+    }
+  }, [gameState, highScore]);
+
+  // Game loop
+  const gameLoop = useCallback(
+    (timestamp: number) => {
+      const deltaTime = timestamp - lastTimeRef.current;
+      lastTimeRef.current = timestamp;
+
+      updateGame(deltaTime);
+      render();
+
+      animationRef.current = requestAnimationFrame(gameLoop);
+    },
+    [updateGame, render],
+  );
+
+  // Initialize game on mount
+  useEffect(() => {
+    initGame();
+  }, [initGame]);
+
+  // Start game loop
+  useEffect(() => {
+    lastTimeRef.current = performance.now();
+    animationRef.current = requestAnimationFrame(gameLoop);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, [gameLoop]);
+
+  // Handle canvas clicks
+  const handleCanvasClick = useCallback(() => {
+    jump();
+  }, [jump]);
+
+  // Handle keyboard input
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.code === "Space" || event.code === "ArrowUp") {
+        event.preventDefault();
+        jump();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, [jump]);
+
+  return (
+    <motion.div
+      className="h-full w-full pt-20 pb-20 px-4 overflow-hidden flex flex-col items-center justify-center"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+    >
+      <div className="bg-white rounded-3xl shadow-xl p-6 max-w-md w-full">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-xl font-bold text-gray-800">
+            Cristais da Memória
+          </h1>
+          <div className="flex gap-2">
+            {gameState.gameStatus === "gameOver" && (
+              <motion.button
+                onClick={initGame}
+                className="p-2 bg-blue-100 text-blue-600 rounded-lg hover:bg-blue-200 transition-colors"
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                title="Reiniciar"
+              >
+                <RotateCcw className="w-4 h-4" />
+              </motion.button>
+            )}
+            <motion.button
+              onClick={onBack}
+              className="p-2 bg-gray-100 text-gray-600 rounded-lg hover:bg-gray-200 transition-colors"
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              title="Voltar"
+            >
+              <ArrowLeft className="w-4 h-4" />
+            </motion.button>
+          </div>
+        </div>
+
+        {/* Game Canvas */}
+        <div className="flex justify-center mb-4">
+          <canvas
+            ref={canvasRef}
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+            className="border-2 border-gray-200 rounded-lg cursor-pointer select-none"
+            onClick={handleCanvasClick}
+            style={{ maxWidth: "100%", height: "auto" }}
+          />
+        </div>
+
+        {/* Controls Info */}
+        <div className="text-center text-sm text-gray-600">
+          <p className="mb-1">🖱️ Clique ou pressione Espaço para voar</p>
+          <p>Evite colidir com as formações cristalinas!</p>
+        </div>
+
+        {/* Stats */}
+        <div className="flex justify-between items-center mt-4 p-3 bg-gray-50 rounded-lg">
+          <div className="text-center">
+            <div className="font-semibold text-gray-800">{gameState.score}</div>
+            <div className="text-xs text-gray-600">Pontuação</div>
+          </div>
+          <div className="text-center">
+            <div className="font-semibold text-gray-800">{highScore}</div>
+            <div className="text-xs text-gray-600">Recorde</div>
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+};

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -27,12 +27,12 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
   // Game constants
   const CANVAS_WIDTH = 400;
   const CANVAS_HEIGHT = 600;
-  const BIRD_SIZE = 20;
+  const BIRD_SIZE = 16; // Smaller bird for easier navigation
   const PIPE_WIDTH = 50;
-  const PIPE_GAP = 150;
-  const GRAVITY = 0.4;
-  const JUMP_FORCE = -7;
-  const PIPE_SPEED = 2;
+  const PIPE_GAP = 180; // Bigger gap between pipes
+  const GRAVITY = 0.3; // Reduced gravity for slower fall
+  const JUMP_FORCE = -6; // Slightly less jump force for better control
+  const PIPE_SPEED = 1.5; // Slower pipe movement
 
   // Game state
   const [bird, setBird] = useState<Bird>({

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
 import { motion } from "framer-motion";
-import { ArrowLeft, RotateCcw } from "lucide-react";
+import { ArrowLeft, RotateCcw, Coins, RefreshCw } from "lucide-react";
+import { useGameStore } from "../../store/gameStore";
 
 interface Bird {
   x: number;

--- a/src/components/Game/MemoryCrystalsGame.tsx
+++ b/src/components/Game/MemoryCrystalsGame.tsx
@@ -93,11 +93,42 @@ export const MemoryCrystalsGame: React.FC<MemoryCrystalsGameProps> = ({
   // Game over
   const endGame = useCallback(() => {
     setGameStatus("gameOver");
+    setShowRewardOptions(true);
     if (score > highScore) {
       setHighScore(score);
       localStorage.setItem("memory-crystals-high-score", score.toString());
     }
   }, [score, highScore]);
+
+  // Reward functions
+  const canClaimReward = dailyRewards < 3 && score > 0;
+
+  const claimXenocoins = useCallback(() => {
+    if (!canClaimReward) return;
+
+    const rewardAmount = score * 10; // 10 xenocoins per point
+    addXenocoins(rewardAmount);
+
+    // Update daily rewards count
+    const today = new Date().toDateString();
+    const newCount = dailyRewards + 1;
+    setDailyRewards(newCount);
+    localStorage.setItem(
+      "memory-crystals-daily-rewards",
+      JSON.stringify({
+        date: today,
+        count: newCount,
+      }),
+    );
+
+    setShowRewardOptions(false);
+    initGame();
+  }, [canClaimReward, score, addXenocoins, dailyRewards, initGame]);
+
+  const tryAgain = useCallback(() => {
+    setShowRewardOptions(false);
+    initGame();
+  }, [initGame]);
 
   // Generate new pipe
   const generatePipe = useCallback((x: number): Pipe => {

--- a/src/components/Pet/EggSelectionScreen.tsx
+++ b/src/components/Pet/EggSelectionScreen.tsx
@@ -77,16 +77,30 @@ export const EggSelectionScreen: React.FC<EggSelectionScreenProps> = ({
     <div className="max-w-md mx-auto">
       {/* Header Card */}
       <motion.div
-        className="bg-white rounded-3xl shadow-xl p-6 border border-gray-100 mb-6 text-center"
+        className="bg-white rounded-3xl shadow-xl p-6 border border-gray-100 mb-6"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
       >
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">
-          Escolha seu Ovo
-        </h2>
-        <p className="text-gray-600">
-          Selecione um ovo para começar sua aventura
-        </p>
+        <div className="flex items-center justify-between mb-4">
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="p-2 rounded-full hover:bg-gray-100 transition-colors"
+            >
+              <ArrowLeft className="w-5 h-5 text-gray-600" />
+            </button>
+          )}
+          <div className={`text-center ${onBack ? "flex-1" : ""}`}>
+            <h2 className="text-2xl font-bold text-gray-900 mb-2">
+              Escolha seu Ovo
+            </h2>
+            <p className="text-gray-600">
+              Selecione um ovo para começar sua aventura
+            </p>
+          </div>
+          {onBack && <div className="w-9" />}{" "}
+          {/* Spacer for center alignment */}
+        </div>
       </motion.div>
 
       {/* Egg Grid */}

--- a/src/components/Pet/EggSelectionScreen.tsx
+++ b/src/components/Pet/EggSelectionScreen.tsx
@@ -44,6 +44,7 @@ interface EggSelectionScreenProps {
 
 export const EggSelectionScreen: React.FC<EggSelectionScreenProps> = ({
   onEggSelected,
+  onBack,
 }) => {
   const [selectedEgg, setSelectedEgg] = useState<Egg | null>(null);
   const [isConfirming, setIsConfirming] = useState(false);

--- a/src/components/Pet/EggSelectionScreen.tsx
+++ b/src/components/Pet/EggSelectionScreen.tsx
@@ -39,6 +39,7 @@ const eggs: Egg[] = [
 
 interface EggSelectionScreenProps {
   onEggSelected: (egg: Egg) => void;
+  onBack?: () => void;
 }
 
 export const EggSelectionScreen: React.FC<EggSelectionScreenProps> = ({

--- a/src/components/Pet/EggSelectionScreen.tsx
+++ b/src/components/Pet/EggSelectionScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Heart, Star } from "lucide-react";
+import { Heart, Star, ArrowLeft } from "lucide-react";
 import { useGameStore } from "../../store/gameStore";
 
 interface Egg {

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -49,7 +49,7 @@ export const ExplorationScreen: React.FC = () => {
     "Saudações, jovem guardião. Este é o Santuário dos Ovos Ancestrais, onde os ovos sagrados aguardam por seus companheiros destinados. Escolha sabiamente, pois esta decisão moldará sua jornada...";
 
   // Alien characters for translation effect
-  const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨⧿⟐⟑ξζηθικλμνοπρστυφχψω";
+  const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨⧿⟐���ξζηθικλμνοπρστυφχψω";
 
   const generateAlienChar = () => {
     return ALIEN_CHARS[Math.floor(Math.random() * ALIEN_CHARS.length)];
@@ -267,7 +267,9 @@ export const ExplorationScreen: React.FC = () => {
                       ? "Guardian da Planície"
                       : currentExplorationPoint.name === "Túneis Profundos"
                         ? "Bahrun"
-                        : "Ancião Guardião"}
+                        : currentExplorationPoint.planetId === "planet-5"
+                          ? "Ancião Guardião"
+                          : "Guardião"}
                   </h3>
                   <div className="w-24 h-0.5 bg-gray-200 mx-auto rounded-full mt-1"></div>
                 </div>
@@ -454,7 +456,7 @@ export const ExplorationScreen: React.FC = () => {
                         name: "Câmaras do Eco",
                         description: "Reproduza sequências sonoras complexas",
                         color: "bg-pink-500",
-                        icon: "🎵",
+                        icon: "��",
                       },
                       {
                         id: "crystal-mining",

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -397,8 +397,8 @@ export const ExplorationScreen: React.FC = () => {
                       );
                     })()}
                   </div>
-                </motion.div>
-              ) : (
+                                </motion.div>
+              ) : currentExplorationPoint.name === "Túneis Profundos" ? (
                 /* Minigame Cards Section for Túneis Profundos */
                 <motion.div
                   initial={{ opacity: 0, y: 20 }}

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -186,7 +186,9 @@ export const ExplorationScreen: React.FC = () => {
               >
                 <div className="text-center mb-3">
                   <h3 className="text-lg font-bold text-gray-800">
-                    Guardian da Planície
+                    {currentExplorationPoint.name === "Planície Dourada"
+                      ? "Guardian da Planície"
+                      : "Bahrun"}
                   </h3>
                   <div className="w-24 h-0.5 bg-gray-200 mx-auto rounded-full mt-1"></div>
                 </div>

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -358,7 +358,7 @@ export const ExplorationScreen: React.FC = () => {
                         description:
                           "Teste sua memória com padrões cristalinos",
                         color: "bg-blue-500",
-                        icon: "����",
+                        icon: "🔹",
                       },
                       {
                         id: "tunnel-runner",
@@ -403,8 +403,14 @@ export const ExplorationScreen: React.FC = () => {
                         whileTap={{ scale: 0.98 }}
                         className="bg-white border border-gray-200 rounded-lg p-3 cursor-pointer hover:shadow-md transition-all"
                         onClick={() => {
-                          // TODO: Implementar navegação para minijogos
-                          alert(`Minijogo "${game.name}" em desenvolvimento!`);
+                          if (game.id === "memory-crystals") {
+                            setCurrentMinigame("memory-crystals");
+                          } else {
+                            // TODO: Implementar outros minijogos
+                            alert(
+                              `Minijogo "${game.name}" em desenvolvimento!`,
+                            );
+                          }
                         }}
                       >
                         <div

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { ArrowLeft, Info, MapPin } from "lucide-react";
 import { useGameStore } from "../../store/gameStore";
 import { MemoryCrystalsGame } from "../Game/MemoryCrystalsGame";
+import { EggSelectionScreen } from "../Pet/EggSelectionScreen";
 
 export const ExplorationScreen: React.FC = () => {
   const {

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -107,6 +107,16 @@ export const ExplorationScreen: React.FC = () => {
     return null;
   }
 
+  // Handle minigame navigation
+  const handleBackFromMinigame = () => {
+    setCurrentMinigame(null);
+  };
+
+  // Render minigame if one is active
+  if (currentMinigame === "memory-crystals") {
+    return <MemoryCrystalsGame onBack={handleBackFromMinigame} />;
+  }
+
   const handleBack = () => {
     setCurrentExplorationPoint(null);
     setCurrentExplorationArea(null);

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -33,6 +33,9 @@ export const ExplorationScreen: React.FC = () => {
   const [isShowingAlien, setIsShowingAlien] = useState(false);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
+  // State for egg selection
+  const [showEggSelection, setShowEggSelection] = useState(false);
+
   // Dialogue text for Planície Dourada
   const GOLDEN_PLAINS_DIALOGUE =
     "Olá, temos algumas naves em nossa coleção especial. Cada uma foi cuidadosamente selecionada para exploradores como você...";

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -233,9 +233,10 @@ export const ExplorationScreen: React.FC = () => {
               )}
           </div>
 
-          {/* Special Content for Planície Dourada and Túneis Profundos */}
+          {/* Special Content for Planície Dourada, Túneis Profundos, and Santuário dos Ovos */}
           {currentExplorationPoint.name === "Planície Dourada" ||
-          currentExplorationPoint.name === "Túneis Profundos" ? (
+          currentExplorationPoint.name === "Túneis Profundos" ||
+          currentExplorationPoint.name === "Santuário dos Ovos" ? (
             <>
               {/* Dialogue Box */}
               <motion.div

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -416,7 +416,7 @@ export const ExplorationScreen: React.FC = () => {
                           <p className="text-xs text-gray-600 leading-tight">
                             {game.description}
                           </p>
-                          <div className="mt-2 bg-purple-100 text-purple-700 px-2 py-1 rounded text-xs font-medium">
+                          <div className="mt-2 bg-gray-100 text-gray-700 px-2 py-1 rounded text-xs font-medium">
                             Em Desenvolvimento
                           </div>
                         </div>

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -263,7 +263,9 @@ export const ExplorationScreen: React.FC = () => {
                   <h3 className="text-lg font-bold text-gray-800">
                     {currentExplorationPoint.name === "Planície Dourada"
                       ? "Guardian da Planície"
-                      : "Bahrun"}
+                      : currentExplorationPoint.name === "Túneis Profundos"
+                        ? "Bahrun"
+                        : "Ancião Guardião"}
                   </h3>
                   <div className="w-24 h-0.5 bg-gray-200 mx-auto rounded-full mt-1"></div>
                 </div>

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -336,13 +336,13 @@ export const ExplorationScreen: React.FC = () => {
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 0.6, duration: 0.4 }}
-                  className="bg-purple-50 border border-purple-200 rounded-xl p-4"
+                  className="bg-gray-50 border border-gray-200 rounded-xl p-4"
                 >
                   <div className="text-center mb-4">
-                    <h4 className="font-semibold text-purple-900 mb-2">
+                    <h4 className="font-semibold text-gray-900 mb-2">
                       Centro de Minijogos
                     </h4>
-                    <div className="text-purple-700 text-xs">
+                    <div className="text-gray-700 text-xs">
                       Teste suas habilidades em desafios únicos
                     </div>
                   </div>

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -397,7 +397,7 @@ export const ExplorationScreen: React.FC = () => {
                       );
                     })()}
                   </div>
-                                </motion.div>
+                </motion.div>
               ) : currentExplorationPoint.name === "Túneis Profundos" ? (
                 /* Minigame Cards Section for Túneis Profundos */
                 <motion.div
@@ -497,6 +497,40 @@ export const ExplorationScreen: React.FC = () => {
                       </motion.div>
                     ))}
                   </div>
+                </motion.div>
+              ) : (
+                /* Egg Selection Section for Santuário dos Ovos */
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.6, duration: 0.4 }}
+                  className="bg-purple-50 border border-purple-200 rounded-xl p-4"
+                >
+                  <div className="text-center mb-4">
+                    <h4 className="font-semibold text-purple-900 mb-2">
+                      Santuário dos Ovos Ancestrais
+                    </h4>
+                    <div className="text-purple-700 text-xs">
+                      Escolha seu companheiro ancestral
+                    </div>
+                  </div>
+
+                  <motion.button
+                    onClick={() => setShowEggSelection(true)}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    className="w-full bg-purple-600 text-white py-4 px-6 rounded-lg font-medium hover:bg-purple-700 transition-colors flex items-center justify-center gap-3"
+                  >
+                    <span className="text-2xl">🥚</span>
+                    <div className="text-left">
+                      <div className="font-semibold">
+                        Escolher Ovo Ancestral
+                      </div>
+                      <div className="text-sm opacity-90">
+                        Comece sua jornada
+                      </div>
+                    </div>
+                  </motion.button>
                 </motion.div>
               )}
             </>

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -143,6 +143,18 @@ export const ExplorationScreen: React.FC = () => {
     return <MemoryCrystalsGame onBack={handleBackFromMinigame} />;
   }
 
+  // Render egg selection if active
+  if (showEggSelection) {
+    return (
+      <div className="pb-24">
+        <EggSelectionScreen
+          onEggSelected={handleEggSelected}
+          onBack={handleBackFromEggSelection}
+        />
+      </div>
+    );
+  }
+
   const handleBack = () => {
     setCurrentExplorationPoint(null);
     setCurrentExplorationArea(null);

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -173,8 +173,9 @@ export const ExplorationScreen: React.FC = () => {
             )}
           </div>
 
-          {/* Planície Dourada Special Content */}
-          {currentExplorationPoint.name === "Planície Dourada" ? (
+          {/* Special Content for Planície Dourada and Túneis Profundos */}
+          {currentExplorationPoint.name === "Planície Dourada" ||
+          currentExplorationPoint.name === "Túneis Profundos" ? (
             <>
               {/* Dialogue Box */}
               <motion.div

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -19,6 +19,10 @@ export const ExplorationScreen: React.FC = () => {
     getOwnedShips,
     purchaseShip,
     xenocoins,
+    selectedEggForHatching,
+    isHatchingInProgress,
+    setSelectedEggForHatching,
+    setIsHatchingInProgress,
   } = useGameStore();
 
   // State for dialogue system (similar to NPCModal)

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -46,7 +46,7 @@ export const ExplorationScreen: React.FC = () => {
 
   // Dialogue text for Santuário dos Ovos
   const EGG_SANCTUARY_DIALOGUE =
-    "Saudações, jovem guardi��o. Este é o Santuário dos Ovos Ancestrais, onde os ovos sagrados aguardam por seus companheiros destinados. Escolha sabiamente, pois esta decisão moldará sua jornada...";
+    "Saudações, jovem guardião. Este é o Santuário dos Ovos Ancestrais, onde os ovos sagrados aguardam por seus companheiros destinados. Escolha sabiamente, pois esta decisão moldará sua jornada...";
 
   // Alien characters for translation effect
   const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨⧿⟐⟑ξζηθικλμνοπρστυφχψω";
@@ -88,10 +88,11 @@ export const ExplorationScreen: React.FC = () => {
   // Typewriter effect for dialogue
   useEffect(() => {
     const pointName = currentExplorationPoint?.name;
+    const planetId = currentExplorationPoint?.planetId;
     if (
       pointName !== "Planície Dourada" &&
       pointName !== "Túneis Profundos" &&
-      pointName !== "Santuário dos Ovos"
+      planetId !== "planet-5"
     ) {
       return;
     }

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -233,7 +233,8 @@ export const ExplorationScreen: React.FC = () => {
 
             {/* Overlay info - only show for locations without special content */}
             {currentExplorationPoint.name !== "Planície Dourada" &&
-              currentExplorationPoint.name !== "Túneis Profundos" && (
+              currentExplorationPoint.name !== "Túneis Profundos" &&
+              currentExplorationPoint.planetId !== "planet-5" && (
                 <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">
                   <div className="text-white">
                     <h3 className="text-lg font-semibold mb-1">

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -34,7 +34,7 @@ export const ExplorationScreen: React.FC = () => {
     "Bem-vindo aos Túneis Profundos, explorador. Estas passagens antigas guardam segredos de civilizações perdidas. Aqui você pode acessar nossos minijogos especiais e testar suas habilidades...";
 
   // Alien characters for translation effect
-  const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨��⟐⟑ξζηθικλμνοπρστυφχψω";
+  const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨⧿⟐⟑ξζηθικλμνοπρστυφχψω";
 
   const generateAlienChar = () => {
     return ALIEN_CHARS[Math.floor(Math.random() * ALIEN_CHARS.length)];
@@ -156,21 +156,22 @@ export const ExplorationScreen: React.FC = () => {
               }`}
             />
 
-            {/* Overlay info - only show for non-Planície Dourada locations */}
-            {currentExplorationPoint.name !== "Planície Dourada" && (
-              <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">
-                <div className="text-white">
-                  <h3 className="text-lg font-semibold mb-1">
-                    {currentExplorationPoint.name}
-                  </h3>
-                  {currentExplorationArea.description && (
-                    <p className="text-sm text-gray-200 leading-relaxed">
-                      {currentExplorationArea.description}
-                    </p>
-                  )}
+            {/* Overlay info - only show for locations without special content */}
+            {currentExplorationPoint.name !== "Planície Dourada" &&
+              currentExplorationPoint.name !== "Túneis Profundos" && (
+                <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">
+                  <div className="text-white">
+                    <h3 className="text-lg font-semibold mb-1">
+                      {currentExplorationPoint.name}
+                    </h3>
+                    {currentExplorationArea.description && (
+                      <p className="text-sm text-gray-200 leading-relaxed">
+                        {currentExplorationArea.description}
+                      </p>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
           </div>
 
           {/* Special Content for Planície Dourada and Túneis Profundos */}
@@ -204,7 +205,7 @@ export const ExplorationScreen: React.FC = () => {
                 </div>
               </motion.div>
 
-                            {/* Content Section */}
+              {/* Content Section */}
               {currentExplorationPoint.name === "Planície Dourada" ? (
                 /* Ship Store Section for Planície Dourada */
                 <motion.div
@@ -343,7 +344,8 @@ export const ExplorationScreen: React.FC = () => {
                       {
                         id: "memory-crystals",
                         name: "Cristais da Memória",
-                        description: "Teste sua memória com padrões cristalinos",
+                        description:
+                          "Teste sua memória com padrões cristalinos",
                         color: "bg-blue-500",
                         icon: "🔹",
                       },
@@ -364,7 +366,8 @@ export const ExplorationScreen: React.FC = () => {
                       {
                         id: "ancient-symbols",
                         name: "Símbolos Ancestrais",
-                        description: "Decifre os mistérios das civilizações perdidas",
+                        description:
+                          "Decifre os mistérios das civilizações perdidas",
                         color: "bg-purple-500",
                         icon: "🔮",
                       },
@@ -393,7 +396,9 @@ export const ExplorationScreen: React.FC = () => {
                           alert(`Minijogo "${game.name}" em desenvolvimento!`);
                         }}
                       >
-                        <div className={`w-full h-20 ${game.color} rounded-lg mb-3 flex items-center justify-center text-2xl text-white`}>
+                        <div
+                          className={`w-full h-20 ${game.color} rounded-lg mb-3 flex items-center justify-center text-2xl text-white`}
+                        >
                           {game.icon}
                         </div>
                         <div className="text-center">
@@ -412,114 +417,6 @@ export const ExplorationScreen: React.FC = () => {
                   </div>
                 </motion.div>
               )}
-                <div className="text-center mb-4">
-                  <h4 className="font-semibold text-blue-900 mb-2">
-                    Loja de Naves
-                  </h4>
-                  <div className="text-blue-700 text-xs">
-                    Naves especiais para exploradores experientes
-                  </div>
-                </div>
-
-                <div className="bg-white border border-blue-100 rounded-lg p-4">
-                  {(() => {
-                    const availableShips = getAllShips().filter(
-                      (ship) => !ship.isDefault,
-                    );
-                    const ownedShips = getOwnedShips();
-
-                    return (
-                      <div className="grid gap-3">
-                        {availableShips.map((ship) => {
-                          const isOwned = ownedShips.find(
-                            (owned) => owned.id === ship.id,
-                          );
-                          const canAfford = xenocoins >= ship.price;
-
-                          return (
-                            <div
-                              key={ship.id}
-                              className="bg-gray-50 rounded-lg border border-gray-200 p-3"
-                            >
-                              <div className="flex items-center gap-3">
-                                {/* Ship Image */}
-                                <div className="flex-shrink-0">
-                                  <img
-                                    src={ship.imageUrl}
-                                    alt={ship.name}
-                                    className="w-16 h-16 object-contain bg-white rounded-lg border border-gray-100"
-                                  />
-                                </div>
-
-                                {/* Ship Info */}
-                                <div className="flex-1 min-w-0">
-                                  <div className="font-semibold text-gray-800 text-sm mb-1">
-                                    {ship.name}
-                                  </div>
-                                  <div className="text-xs text-gray-600 mb-2 line-clamp-2">
-                                    {ship.description}
-                                  </div>
-                                  <div className="flex items-center gap-2 text-xs">
-                                    <span className="bg-green-100 text-green-700 px-2 py-1 rounded">
-                                      +
-                                      {((ship.stats.speed - 1) * 100).toFixed(
-                                        0,
-                                      )}
-                                      % Velocidade
-                                    </span>
-                                    <span className="bg-red-100 text-red-700 px-2 py-1 rounded">
-                                      +
-                                      {(
-                                        (ship.stats.projectileDamage - 1) *
-                                        100
-                                      ).toFixed(0)}
-                                      % Dano
-                                    </span>
-                                  </div>
-                                </div>
-
-                                {/* Price and Buy Button */}
-                                <div className="text-center">
-                                  <div className="flex items-center justify-center gap-1 mb-2">
-                                    <img
-                                      src="https://cdn.builder.io/api/v1/image/assets%2Ff481900009a94cda953c032479392a30%2F3e6c6cb85c6a4d2ba05acb245bfbc214?format=webp&width=800"
-                                      alt="Xenocoins"
-                                      className="w-4 h-4"
-                                    />
-                                    <span className="font-semibold text-sm text-gray-800">
-                                      {ship.price}
-                                    </span>
-                                  </div>
-
-                                  {isOwned ? (
-                                    <div className="bg-green-100 text-green-700 px-3 py-1 rounded-md text-xs font-medium">
-                                      Possuída
-                                    </div>
-                                  ) : (
-                                    <motion.button
-                                      whileHover={{ scale: 1.05 }}
-                                      whileTap={{ scale: 0.95 }}
-                                      onClick={() => purchaseShip(ship.id)}
-                                      disabled={!canAfford}
-                                      className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
-                                        canAfford
-                                          ? "bg-blue-600 text-white hover:bg-blue-700"
-                                          : "bg-gray-300 text-gray-500 cursor-not-allowed"
-                                      }`}
-                                    >
-                                      {canAfford ? "Comprar" : "Sem Moeda"}
-                                    </motion.button>
-                                  )}
-                                </div>
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    );
-                  })()}
-                </div>
-              </motion.div>
             </>
           ) : (
             /* Additional Info Panel for other locations */

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -138,7 +138,8 @@ export const ExplorationScreen: React.FC = () => {
           {/* Main Image */}
           <div
             className={`w-full relative rounded-2xl overflow-hidden mb-4 ${
-              currentExplorationPoint.name === "Planície Dourada"
+              currentExplorationPoint.name === "Planície Dourada" ||
+              currentExplorationPoint.name === "Túneis Profundos"
                 ? "h-80 sm:h-96"
                 : "h-[calc(100vh-280px)] sm:h-[calc(100vh-300px)] md:h-[calc(100vh-320px)] lg:h-[calc(100vh-340px)]"
             }`}
@@ -150,7 +151,8 @@ export const ExplorationScreen: React.FC = () => {
               src={currentExplorationArea.imageUrl}
               alt={currentExplorationArea.name}
               className={`w-full h-full ${
-                currentExplorationPoint.name === "Planície Dourada"
+                currentExplorationPoint.name === "Planície Dourada" ||
+                currentExplorationPoint.name === "Túneis Profundos"
                   ? "object-contain bg-gradient-to-b from-blue-50 to-blue-100"
                   : "object-cover"
               }`}

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -71,7 +71,11 @@ export const ExplorationScreen: React.FC = () => {
   // Reset dialogue when point changes
   useEffect(() => {
     const pointName = currentExplorationPoint?.name;
-    if (pointName === "Planície Dourada" || pointName === "Túneis Profundos") {
+    if (
+      pointName === "Planície Dourada" ||
+      pointName === "Túneis Profundos" ||
+      pointName === "Santuário dos Ovos"
+    ) {
       setDisplayedText("");
       setCurrentIndex(0);
       setIsTypingComplete(false);
@@ -83,14 +87,20 @@ export const ExplorationScreen: React.FC = () => {
   // Typewriter effect for dialogue
   useEffect(() => {
     const pointName = currentExplorationPoint?.name;
-    if (pointName !== "Planície Dourada" && pointName !== "Túneis Profundos") {
+    if (
+      pointName !== "Planície Dourada" &&
+      pointName !== "Túneis Profundos" &&
+      pointName !== "Santuário dos Ovos"
+    ) {
       return;
     }
 
     const dialogue =
       pointName === "Planície Dourada"
         ? GOLDEN_PLAINS_DIALOGUE
-        : DEEP_TUNNELS_DIALOGUE;
+        : pointName === "Túneis Profundos"
+          ? DEEP_TUNNELS_DIALOGUE
+          : EGG_SANCTUARY_DIALOGUE;
 
     if (currentIndex < dialogue.length) {
       // First show alien character

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -53,6 +53,18 @@ export const ExplorationScreen: React.FC = () => {
     setCurrentExplorationArea,
   ]);
 
+  // Reset dialogue when point changes
+  useEffect(() => {
+    const pointName = currentExplorationPoint?.name;
+    if (pointName === "Planície Dourada" || pointName === "Túneis Profundos") {
+      setDisplayedText("");
+      setCurrentIndex(0);
+      setIsTypingComplete(false);
+      setCurrentAlienChar("");
+      setIsShowingAlien(false);
+    }
+  }, [currentExplorationPoint?.name]);
+
   // Typewriter effect for dialogue
   useEffect(() => {
     const pointName = currentExplorationPoint?.name;
@@ -64,12 +76,6 @@ export const ExplorationScreen: React.FC = () => {
       pointName === "Planície Dourada"
         ? GOLDEN_PLAINS_DIALOGUE
         : DEEP_TUNNELS_DIALOGUE;
-
-    setDisplayedText("");
-    setCurrentIndex(0);
-    setIsTypingComplete(false);
-    setCurrentAlienChar("");
-    setIsShowingAlien(false);
 
     if (currentIndex < dialogue.length) {
       // First show alien character
@@ -92,7 +98,7 @@ export const ExplorationScreen: React.FC = () => {
         clearTimeout(intervalRef.current);
       }
     };
-  }, [currentExplorationPoint, currentIndex]);
+  }, [currentIndex, currentExplorationPoint?.name]);
 
   if (!currentExplorationPoint || !currentExplorationArea) {
     return null;

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -204,13 +204,214 @@ export const ExplorationScreen: React.FC = () => {
                 </div>
               </motion.div>
 
-              {/* Ship Store Section */}
-              <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.6, duration: 0.4 }}
-                className="bg-blue-50 border border-blue-200 rounded-xl p-4"
-              >
+                            {/* Content Section */}
+              {currentExplorationPoint.name === "Planície Dourada" ? (
+                /* Ship Store Section for Planície Dourada */
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.6, duration: 0.4 }}
+                  className="bg-blue-50 border border-blue-200 rounded-xl p-4"
+                >
+                  <div className="text-center mb-4">
+                    <h4 className="font-semibold text-blue-900 mb-2">
+                      Loja de Naves
+                    </h4>
+                    <div className="text-blue-700 text-xs">
+                      Naves especiais para exploradores experientes
+                    </div>
+                  </div>
+
+                  <div className="bg-white border border-blue-100 rounded-lg p-4">
+                    {(() => {
+                      const availableShips = getAllShips().filter(
+                        (ship) => !ship.isDefault,
+                      );
+                      const ownedShips = getOwnedShips();
+
+                      return (
+                        <div className="grid gap-3">
+                          {availableShips.map((ship) => {
+                            const isOwned = ownedShips.find(
+                              (owned) => owned.id === ship.id,
+                            );
+                            const canAfford = xenocoins >= ship.price;
+
+                            return (
+                              <div
+                                key={ship.id}
+                                className="bg-gray-50 rounded-lg border border-gray-200 p-3"
+                              >
+                                <div className="flex items-center gap-3">
+                                  {/* Ship Image */}
+                                  <div className="flex-shrink-0">
+                                    <img
+                                      src={ship.imageUrl}
+                                      alt={ship.name}
+                                      className="w-16 h-16 object-contain bg-white rounded-lg border border-gray-100"
+                                    />
+                                  </div>
+
+                                  {/* Ship Info */}
+                                  <div className="flex-1 min-w-0">
+                                    <div className="font-semibold text-gray-800 text-sm mb-1">
+                                      {ship.name}
+                                    </div>
+                                    <div className="text-xs text-gray-600 mb-2 line-clamp-2">
+                                      {ship.description}
+                                    </div>
+                                    <div className="flex items-center gap-2 text-xs">
+                                      <span className="bg-green-100 text-green-700 px-2 py-1 rounded">
+                                        +
+                                        {((ship.stats.speed - 1) * 100).toFixed(
+                                          0,
+                                        )}
+                                        % Velocidade
+                                      </span>
+                                      <span className="bg-red-100 text-red-700 px-2 py-1 rounded">
+                                        +
+                                        {(
+                                          (ship.stats.projectileDamage - 1) *
+                                          100
+                                        ).toFixed(0)}
+                                        % Dano
+                                      </span>
+                                    </div>
+                                  </div>
+
+                                  {/* Price and Buy Button */}
+                                  <div className="text-center">
+                                    <div className="flex items-center justify-center gap-1 mb-2">
+                                      <img
+                                        src="https://cdn.builder.io/api/v1/image/assets%2Ff481900009a94cda953c032479392a30%2F3e6c6cb85c6a4d2ba05acb245bfbc214?format=webp&width=800"
+                                        alt="Xenocoins"
+                                        className="w-4 h-4"
+                                      />
+                                      <span className="font-semibold text-sm text-gray-800">
+                                        {ship.price}
+                                      </span>
+                                    </div>
+
+                                    {isOwned ? (
+                                      <div className="bg-green-100 text-green-700 px-3 py-1 rounded-md text-xs font-medium">
+                                        Possuída
+                                      </div>
+                                    ) : (
+                                      <motion.button
+                                        whileHover={{ scale: 1.05 }}
+                                        whileTap={{ scale: 0.95 }}
+                                        onClick={() => purchaseShip(ship.id)}
+                                        disabled={!canAfford}
+                                        className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
+                                          canAfford
+                                            ? "bg-blue-600 text-white hover:bg-blue-700"
+                                            : "bg-gray-300 text-gray-500 cursor-not-allowed"
+                                        }`}
+                                      >
+                                        {canAfford ? "Comprar" : "Sem Moeda"}
+                                      </motion.button>
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      );
+                    })()}
+                  </div>
+                </motion.div>
+              ) : (
+                /* Minigame Cards Section for Túneis Profundos */
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.6, duration: 0.4 }}
+                  className="bg-purple-50 border border-purple-200 rounded-xl p-4"
+                >
+                  <div className="text-center mb-4">
+                    <h4 className="font-semibold text-purple-900 mb-2">
+                      Centro de Minijogos
+                    </h4>
+                    <div className="text-purple-700 text-xs">
+                      Teste suas habilidades em desafios únicos
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    {[
+                      {
+                        id: "memory-crystals",
+                        name: "Cristais da Memória",
+                        description: "Teste sua memória com padrões cristalinos",
+                        color: "bg-blue-500",
+                        icon: "🔹",
+                      },
+                      {
+                        id: "tunnel-runner",
+                        name: "Corredor dos Túneis",
+                        description: "Navigate pelos túneis em alta velocidade",
+                        color: "bg-green-500",
+                        icon: "🏃",
+                      },
+                      {
+                        id: "energy-puzzle",
+                        name: "Quebra-Cabeça Energético",
+                        description: "Resolva circuitos de energia antiga",
+                        color: "bg-yellow-500",
+                        icon: "⚡",
+                      },
+                      {
+                        id: "ancient-symbols",
+                        name: "Símbolos Ancestrais",
+                        description: "Decifre os mistérios das civilizações perdidas",
+                        color: "bg-purple-500",
+                        icon: "🔮",
+                      },
+                      {
+                        id: "echo-chambers",
+                        name: "Câmaras do Eco",
+                        description: "Reproduza sequências sonoras complexas",
+                        color: "bg-pink-500",
+                        icon: "🎵",
+                      },
+                      {
+                        id: "crystal-mining",
+                        name: "Mineração de Cristais",
+                        description: "Extraia cristais preciosos com precisão",
+                        color: "bg-indigo-500",
+                        icon: "⛏️",
+                      },
+                    ].map((game) => (
+                      <motion.div
+                        key={game.id}
+                        whileHover={{ scale: 1.02 }}
+                        whileTap={{ scale: 0.98 }}
+                        className="bg-white border border-gray-200 rounded-lg p-3 cursor-pointer hover:shadow-md transition-all"
+                        onClick={() => {
+                          // TODO: Implementar navegação para minijogos
+                          alert(`Minijogo "${game.name}" em desenvolvimento!`);
+                        }}
+                      >
+                        <div className={`w-full h-20 ${game.color} rounded-lg mb-3 flex items-center justify-center text-2xl text-white`}>
+                          {game.icon}
+                        </div>
+                        <div className="text-center">
+                          <h5 className="font-semibold text-gray-800 text-xs mb-1">
+                            {game.name}
+                          </h5>
+                          <p className="text-xs text-gray-600 leading-tight">
+                            {game.description}
+                          </p>
+                          <div className="mt-2 bg-purple-100 text-purple-700 px-2 py-1 rounded text-xs font-medium">
+                            Em Desenvolvimento
+                          </div>
+                        </div>
+                      </motion.div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
                 <div className="text-center mb-4">
                   <h4 className="font-semibold text-blue-900 mb-2">
                     Loja de Naves

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -247,10 +247,10 @@ export const ExplorationScreen: React.FC = () => {
               )}
           </div>
 
-          {/* Special Content for Planície Dourada, Túneis Profundos, and Santuário dos Ovos */}
+          {/* Special Content for Planície Dourada, Túneis Profundos, and Vila Ancestral */}
           {currentExplorationPoint.name === "Planície Dourada" ||
           currentExplorationPoint.name === "Túneis Profundos" ||
-          currentExplorationPoint.name === "Santuário dos Ovos" ? (
+          currentExplorationPoint.planetId === "planet-5" ? (
             <>
               {/* Dialogue Box */}
               <motion.div

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -504,7 +504,7 @@ export const ExplorationScreen: React.FC = () => {
                   </div>
                 </motion.div>
               ) : (
-                /* Egg Selection Section for Santuário dos Ovos */
+                /* Egg Selection Section for Vila Ancestral */
                 <motion.div
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -120,6 +120,24 @@ export const ExplorationScreen: React.FC = () => {
     setCurrentMinigame(null);
   };
 
+  // Handle egg selection
+  const handleEggSelected = (egg: any) => {
+    setSelectedEggForHatching(egg);
+    setIsHatchingInProgress(true);
+    setShowEggSelection(false);
+    // Navigate back to pet screen to show hatching
+    setCurrentExplorationPoint(null);
+    setCurrentExplorationArea(null);
+    setCurrentScreen("world");
+    setTimeout(() => {
+      setCurrentScreen("pet");
+    }, 100);
+  };
+
+  const handleBackFromEggSelection = () => {
+    setShowEggSelection(false);
+  };
+
   // Render minigame if one is active
   if (currentMinigame === "memory-crystals") {
     return <MemoryCrystalsGame onBack={handleBackFromMinigame} />;

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from "react";
 import { motion } from "framer-motion";
 import { ArrowLeft, Info, MapPin } from "lucide-react";
 import { useGameStore } from "../../store/gameStore";
+import { MemoryCrystalsGame } from "../Game/MemoryCrystalsGame";
 
 export const ExplorationScreen: React.FC = () => {
   const {

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -8,9 +8,11 @@ export const ExplorationScreen: React.FC = () => {
   const {
     currentExplorationPoint,
     currentExplorationArea,
+    currentMinigame,
     setCurrentScreen,
     setCurrentExplorationPoint,
     setCurrentExplorationArea,
+    setCurrentMinigame,
     getExplorationArea,
     getAllShips,
     getOwnedShips,
@@ -356,7 +358,7 @@ export const ExplorationScreen: React.FC = () => {
                         description:
                           "Teste sua memória com padrões cristalinos",
                         color: "bg-blue-500",
-                        icon: "🔹",
+                        icon: "����",
                       },
                       {
                         id: "tunnel-runner",

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -53,11 +53,17 @@ export const ExplorationScreen: React.FC = () => {
     setCurrentExplorationArea,
   ]);
 
-  // Typewriter effect for Planície Dourada dialogue
+  // Typewriter effect for dialogue
   useEffect(() => {
-    if (currentExplorationPoint?.name !== "Planície Dourada") {
+    const pointName = currentExplorationPoint?.name;
+    if (pointName !== "Planície Dourada" && pointName !== "Túneis Profundos") {
       return;
     }
+
+    const dialogue =
+      pointName === "Planície Dourada"
+        ? GOLDEN_PLAINS_DIALOGUE
+        : DEEP_TUNNELS_DIALOGUE;
 
     setDisplayedText("");
     setCurrentIndex(0);
@@ -65,7 +71,7 @@ export const ExplorationScreen: React.FC = () => {
     setCurrentAlienChar("");
     setIsShowingAlien(false);
 
-    if (currentIndex < GOLDEN_PLAINS_DIALOGUE.length) {
+    if (currentIndex < dialogue.length) {
       // First show alien character
       setIsShowingAlien(true);
       setCurrentAlienChar(generateAlienChar());
@@ -73,7 +79,7 @@ export const ExplorationScreen: React.FC = () => {
       // After showing alien char, replace with real character
       intervalRef.current = setTimeout(() => {
         setIsShowingAlien(false);
-        setDisplayedText((prev) => prev + GOLDEN_PLAINS_DIALOGUE[currentIndex]);
+        setDisplayedText((prev) => prev + dialogue[currentIndex]);
         setCurrentIndex((prev) => prev + 1);
       }, 40); // Show alien char for 40ms, then continue quickly
     } else {

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -46,7 +46,7 @@ export const ExplorationScreen: React.FC = () => {
 
   // Dialogue text for Santuário dos Ovos
   const EGG_SANCTUARY_DIALOGUE =
-    "Saudações, jovem guardião. Este é o Santuário dos Ovos Ancestrais, onde os ovos sagrados aguardam por seus companheiros destinados. Escolha sabiamente, pois esta decisão moldará sua jornada...";
+    "Saudações, jovem guardi��o. Este é o Santuário dos Ovos Ancestrais, onde os ovos sagrados aguardam por seus companheiros destinados. Escolha sabiamente, pois esta decisão moldará sua jornada...";
 
   // Alien characters for translation effect
   const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨⧿⟐⟑ξζηθικλμνοπρστυφχψω";
@@ -71,10 +71,11 @@ export const ExplorationScreen: React.FC = () => {
   // Reset dialogue when point changes
   useEffect(() => {
     const pointName = currentExplorationPoint?.name;
+    const planetId = currentExplorationPoint?.planetId;
     if (
       pointName === "Planície Dourada" ||
       pointName === "Túneis Profundos" ||
-      pointName === "Santuário dos Ovos"
+      planetId === "planet-5"
     ) {
       setDisplayedText("");
       setCurrentIndex(0);
@@ -82,7 +83,7 @@ export const ExplorationScreen: React.FC = () => {
       setCurrentAlienChar("");
       setIsShowingAlien(false);
     }
-  }, [currentExplorationPoint?.name]);
+  }, [currentExplorationPoint?.name, currentExplorationPoint?.planetId]);
 
   // Typewriter effect for dialogue
   useEffect(() => {

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -513,10 +513,10 @@ export const ExplorationScreen: React.FC = () => {
                 >
                   <div className="text-center mb-4">
                     <h4 className="font-semibold text-purple-900 mb-2">
-                      Santuário dos Ovos Ancestrais
+                      Vila Ancestral - Seleção de Ovos
                     </h4>
                     <div className="text-purple-700 text-xs">
-                      Escolha seu companheiro ancestral
+                      Escolha seu primeiro companheiro para começar sua jornada
                     </div>
                   </div>
 

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -44,6 +44,10 @@ export const ExplorationScreen: React.FC = () => {
   const DEEP_TUNNELS_DIALOGUE =
     "Bem-vindo aos Túneis Profundos, explorador. Estas passagens antigas guardam segredos de civilizações perdidas. Aqui você pode acessar nossos minijogos especiais e testar suas habilidades...";
 
+  // Dialogue text for Santuário dos Ovos
+  const EGG_SANCTUARY_DIALOGUE =
+    "Saudações, jovem guardião. Este é o Santuário dos Ovos Ancestrais, onde os ovos sagrados aguardam por seus companheiros destinados. Escolha sabiamente, pois esta decisão moldará sua jornada...";
+
   // Alien characters for translation effect
   const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨⧿⟐⟑ξζηθικλμνοπρστυφχψω";
 

--- a/src/components/Screens/ExplorationScreen.tsx
+++ b/src/components/Screens/ExplorationScreen.tsx
@@ -29,6 +29,10 @@ export const ExplorationScreen: React.FC = () => {
   const GOLDEN_PLAINS_DIALOGUE =
     "Olá, temos algumas naves em nossa coleção especial. Cada uma foi cuidadosamente selecionada para exploradores como você...";
 
+  // Dialogue text for Túneis Profundos
+  const DEEP_TUNNELS_DIALOGUE =
+    "Bem-vindo aos Túneis Profundos, explorador. Estas passagens antigas guardam segredos de civilizações perdidas. Aqui você pode acessar nossos minijogos especiais e testar suas habilidades...";
+
   // Alien characters for translation effect
   const ALIEN_CHARS = "◊◈◇◆☾☽⟡⟢⧿⧾⬟⬠⬢⬣⬡⬠⧨��⟐⟑ξζηθικλμνοπρστυφχψω";
 

--- a/src/components/Screens/PetScreen.tsx
+++ b/src/components/Screens/PetScreen.tsx
@@ -62,12 +62,38 @@ export const PetScreen: React.FC = () => {
     );
   }
 
-  // If no pets exist, show egg selection screen
+  // If no pets exist, show message to go to Vila Ancestral
   if (!activePet && pets.length === 0) {
     return (
-      <div className="pb-24">
-        <EggSelectionScreen onEggSelected={handleEggSelected} />
-      </div>
+      <motion.div
+        className="max-w-md mx-auto pb-24"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+      >
+        <div className="bg-white rounded-3xl shadow-xl p-8 border border-gray-100 text-center">
+          <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Plus className="w-12 h-12 text-gray-400" />
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            Nenhum Pet Encontrado
+          </h2>
+          <p className="text-gray-600 mb-6">
+            Visite a Vila Ancestral para escolher seu primeiro ovo e criar seu
+            pet!
+          </p>
+          <motion.button
+            onClick={() => {
+              setCurrentScreen("world");
+              // Navigate to Vila Ancestral will be handled by the auto-redirect logic
+            }}
+            className="px-6 py-3 bg-purple-600 text-white rounded-full font-medium hover:bg-purple-700 transition-colors"
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+          >
+            Ir para Vila Ancestral
+          </motion.button>
+        </div>
+      </motion.div>
     );
   }
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -40,6 +40,10 @@ interface GameStore extends GameState {
   generateExplorationPoints: (planetId: string) => ExplorationPoint[];
   getExplorationArea: (pointId: string) => ExplorationArea;
 
+  // Minigames
+  currentMinigame: string | null;
+  setCurrentMinigame: (minigame: string | null) => void;
+
   // Planet editing mode (admin only)
   isPlanetEditMode: boolean;
   setPlanetEditMode: (enabled: boolean) => void;

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -903,6 +903,9 @@ export const useGameStore = create<GameStore>()(
       setCurrentExplorationArea: (area) =>
         set({ currentExplorationArea: area }),
 
+      // Minigames
+      setCurrentMinigame: (minigame) => set({ currentMinigame: minigame }),
+
       generateExplorationPoints: (planetId) => {
         // First try to load from storage
         const stored = get().loadExplorationPointsFromStorage(planetId);

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -805,6 +805,9 @@ export const useGameStore = create<GameStore>()(
       currentExplorationArea: null,
       explorationPoints: [],
 
+      // Minigames state
+      currentMinigame: null,
+
       // Planet editing state
       isPlanetEditMode: false,
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -986,56 +986,6 @@ export const useGameStore = create<GameStore>()(
         for (let i = 0; i < planetId.length; i++) {
           hash = ((hash << 5) - hash + planetId.charCodeAt(i)) & 0xffffffff;
         }
-        // Special handling for Vila Ancestral (planet-5)
-        if (planetId === "planet-5") {
-          const vilaPoints: ExplorationPoint[] = [
-            {
-              id: `${planetId}_point_1`,
-              planetId,
-              name: "Santuário dos Ovos",
-              x: 30,
-              y: 40,
-              imageUrl:
-                "https://cdn.builder.io/api/v1/image/assets%2Ff94d2a386a444693b9fbdff90d783a66%2F76c4f943e6e045938d8e5efb84a2a969?format=webp&width=800",
-              description:
-                "O local sagrado onde os ovos ancestrais são guardados e escolhidos pelos novos guardiões.",
-              discovered: false,
-              size: 1.2,
-              active: true,
-            },
-            {
-              id: `${planetId}_point_2`,
-              planetId,
-              name: "Templo dos Ancestrais",
-              x: 60,
-              y: 30,
-              imageUrl:
-                "https://cdn.builder.io/api/v1/image/assets%2F6b84993f22904beeb2e1d8d2f128c032%2Faaff2921868f4bbfb24be01b9fdfa6a1?format=webp&width=800",
-              description:
-                "Um antigo templo onde os anciões compartilham sabedoria sobre os pets ancestrais.",
-              discovered: false,
-              size: 1.0,
-              active: true,
-            },
-            {
-              id: `${planetId}_point_3`,
-              planetId,
-              name: "Jardim Sagrado",
-              x: 45,
-              y: 70,
-              imageUrl:
-                "https://cdn.builder.io/api/v1/image/assets%2F6b84993f22904beeb2e1d8d2f128c032%2Faaff2921868f4bbfb24be01b9fdfa6a1?format=webp&width=800",
-              description:
-                "Um jardim místico onde os pets recém-nascidos fazem seus primeiros passos.",
-              discovered: false,
-              size: 1.0,
-              active: true,
-            },
-          ];
-
-          set({ explorationPoints: vilaPoints });
-          return vilaPoints;
-        }
 
         const setIndex = Math.abs(hash) % pointTemplates.length;
         const selectedNames = pointTemplates[setIndex];
@@ -2412,7 +2362,7 @@ export const useGameStore = create<GameStore>()(
         // Se já tem posições no store, usa elas
         if (state.worldPositions.length > 0) {
           console.log(
-            "��� Using world positions from store:",
+            "📍 Using world positions from store:",
             state.worldPositions,
           );
           return;

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -986,6 +986,57 @@ export const useGameStore = create<GameStore>()(
         for (let i = 0; i < planetId.length; i++) {
           hash = ((hash << 5) - hash + planetId.charCodeAt(i)) & 0xffffffff;
         }
+        // Special handling for Vila Ancestral (planet-5)
+        if (planetId === "planet-5") {
+          const vilaPoints: ExplorationPoint[] = [
+            {
+              id: `${planetId}_point_1`,
+              planetId,
+              name: "Santuário dos Ovos",
+              x: 30,
+              y: 40,
+              imageUrl:
+                "https://cdn.builder.io/api/v1/image/assets%2Ff94d2a386a444693b9fbdff90d783a66%2F76c4f943e6e045938d8e5efb84a2a969?format=webp&width=800",
+              description:
+                "O local sagrado onde os ovos ancestrais são guardados e escolhidos pelos novos guardiões.",
+              discovered: false,
+              size: 1.2,
+              active: true,
+            },
+            {
+              id: `${planetId}_point_2`,
+              planetId,
+              name: "Templo dos Ancestrais",
+              x: 60,
+              y: 30,
+              imageUrl:
+                "https://cdn.builder.io/api/v1/image/assets%2F6b84993f22904beeb2e1d8d2f128c032%2Faaff2921868f4bbfb24be01b9fdfa6a1?format=webp&width=800",
+              description:
+                "Um antigo templo onde os anciões compartilham sabedoria sobre os pets ancestrais.",
+              discovered: false,
+              size: 1.0,
+              active: true,
+            },
+            {
+              id: `${planetId}_point_3`,
+              planetId,
+              name: "Jardim Sagrado",
+              x: 45,
+              y: 70,
+              imageUrl:
+                "https://cdn.builder.io/api/v1/image/assets%2F6b84993f22904beeb2e1d8d2f128c032%2Faaff2921868f4bbfb24be01b9fdfa6a1?format=webp&width=800",
+              description:
+                "Um jardim místico onde os pets recém-nascidos fazem seus primeiros passos.",
+              discovered: false,
+              size: 1.0,
+              active: true,
+            },
+          ];
+
+          set({ explorationPoints: vilaPoints });
+          return vilaPoints;
+        }
+
         const setIndex = Math.abs(hash) % pointTemplates.length;
         const selectedNames = pointTemplates[setIndex];
 
@@ -2361,7 +2412,7 @@ export const useGameStore = create<GameStore>()(
         // Se já tem posições no store, usa elas
         if (state.worldPositions.length > 0) {
           console.log(
-            "📍 Using world positions from store:",
+            "��� Using world positions from store:",
             state.worldPositions,
           );
           return;


### PR DESCRIPTION
This pull request adds a new Memory Crystals minigame and implements redirect logic for users without pets.

**Changes made:**

- **Added Memory Crystals minigame component** (`MemoryCrystalsGame.tsx`):
  - Flappy Bird-style game with crystal theme
  - Daily reward system (3 rewards per day)
  - Xenocoins rewards based on score
  - Canvas-based rendering with crystal graphics
  - Gentle physics and larger gaps for easier gameplay

- **Added pet redirect logic in App.tsx**:
  - New useEffect that redirects users without pets to Vila Ancestral
  - Added pets and activePet to game context
  - Automatic navigation to planet-5 (Vila Ancestral) when user has no pets

- **Updated PetScreen.tsx**:
  - Changed behavior when no pets exist
  - Now shows message directing users to Vila Ancestral instead of egg selection
  - Added button to navigate to world map

- **Enhanced PlanetScreen.tsx**:
  - Added minigame selection interface for Túneis Profundos
  - Memory Crystals game integration
  - Placeholder UI for other upcoming minigames

- **Updated gameStore.ts**:
  - Added currentMinigame state management
  - Updated exploration point generation for Túneis Profundos
  - Changed store version to v2
  - Updated ship image URL

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/613b0870c3174343a1d6b971b7e3877b/glow-sanctuary)

👀 [Preview Link](https://613b0870c3174343a1d6b971b7e3877b-glow-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>613b0870c3174343a1d6b971b7e3877b</projectId>-->
<!--<branchName>glow-sanctuary</branchName>-->